### PR TITLE
Быстрый просмотр (quicklook)

### DIFF
--- a/js/commands/quicklook.js
+++ b/js/commands/quicklook.js
@@ -85,8 +85,8 @@ elFinder.prototype.commands.quicklook = function() {
 				opacity : 1,
 				width  : width,
 				height : height,
-				top    : parseInt(parent.position().top + win.scrollTop()),
-				left   : parseInt((win.width() - width)/2)
+				top    : parseInt((win.height() - height)/2 + win.scrollTop()),
+				left   : parseInt((win.width() - width)/2 + win.scrollLeft())
 			}
 		},
 		


### PR DESCRIPTION
В режиме "Диалог", если расположить File Manager очень низко, "Preview" (quicklook) не видно (оно располагается ещё ниже), т.к оно будет расположено на расстояние: Позиция FM + Скролл, также не учитывается горизонтальный скролл. При предложенных изменениях "Preview" (quicklook) будет всегда по центру экрана
