### PR TITLE
fix when i use 1.x connector can't resize image, Lack parm 'current'.

### DIFF
--- a/js/commands/resize.js
+++ b/js/commands/resize.js
@@ -217,6 +217,7 @@ elFinder.prototype.commands.resize = function() {
 							data : {
 								cmd    : 'resize',
 								target : file.hash,
+								current: file.phash,
 								width  : w,
 								height : h,
 								crop   : resize ? 0 : 1


### PR DESCRIPTION
ps: i use python connector.
