### PR TITLE
Fix when i use 1.x connector,　i can't 'Archive', Lack parm 'name'.

### DIFF
--- a/js/commands/archive.js
+++ b/js/commands/archive.js
@@ -57,7 +57,7 @@ elFinder.prototype.commands.archive = function() {
 		}
 
 		return fm.request({
-			data       : {cmd : 'archive', targets : this.hashes(hashes), type : mime},
+			data       : {cmd : 'archive', targets : this.hashes(hashes), type : mime, name : 'Archive'},
 			notify     : {type : 'archive', cnt : 1},
 			syncOnFail : true
 		});


### PR DESCRIPTION
PS:i use python connector.
