### PR TITLE
Some faults about file download are corrected.

### DIFF
--- a/js/commands/download.js
+++ b/js/commands/download.js
@@ -21,7 +21,7 @@ elFinder.prototype.commands.download = function() {
 		var sel = this.fm.selected(),
 			cnt = sel.length;
 		
-		return  !this._disabled && cnt && cnt == filter(sel).length ? 0 : -1;
+		return  !this._disabled && cnt && (!$.browser.msie || cnt == 1) && cnt == filter(sel).length ? 0 : -1;
 	}
 	
 	this.exec = function(hashes) {
@@ -41,16 +41,16 @@ elFinder.prototype.commands.download = function() {
 		}
 			
 		base += base.indexOf('?') === -1 ? '?' : '&';
-			
+		
 		for (i = 0; i < files.length; i++) {
-			var iframe = $('<iframe style="display:none" src="'+base + 'cmd=file&target=' + files[i].hash+'&download=1'+'"/>')
-				.appendTo('body')
-				.load(function() {
-					setTimeout(function() {
-						iframe.remove();
-					}, 1000)
-				});
+			iframe = $('<iframe class="downloader" style="display:none" src="'+base + 'cmd=file&target=' + files[i].hash+'&download=1'+'"/>')
+				.appendTo('body');
 		}
+		iframe.ready(function() {
+			setTimeout(function() {
+				$('body iframe.downloader').remove();
+			}, $.browser.mozilla? (10000 * i + 1) : 1000);
+		});
 		return dfrd.resolve(hashes);
 	}
 


### PR DESCRIPTION
Hello! thanks.
- IE cannot perform multi-download.
- &lt;iframe&gt; is required for it until Firefox displays a preservation
  place
- dialog by setup which chooses a preservation place.
- &lt;iframe&gt; remains at the time of multi-download.
- "ready" is used for the browser which "onload" does not fire.
