### PR TITLE
Fix for multiple instances with different roots.

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -1819,8 +1819,8 @@ elFinder.prototype = {
 	
 	uploads : {
 		// upload transport using iframe
-		iframe : function(data) { 
-			var self   = this,
+		iframe : function(data, rm) { 
+			var self   = fm ? fm : this,
 				input  = data.input,
 				dfrd   = $.Deferred()
 					.fail(function(error) {
@@ -1905,8 +1905,8 @@ elFinder.prototype = {
 			return dfrd;
 		},
 		// upload transport using XMLHttpRequest
-		xhr : function(data) { 
-			var self   = this,
+		xhr : function(data, fm) { 
+			var self   = fm ? fm : this,
 				dfrd   = $.Deferred()
 					.fail(function(error) {
 						error && self.error(error);


### PR DESCRIPTION
The transport.upload method is called with two arguments, but doesn't accept two arguments. Adding the second argument lets multiple instances of elFinder with different root folders work on the same page. Before this change, the one loaded first would always receive any uploaded files.
