### PR TITLE
Fixed typo in reference to dragUploadAllow option.

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -1338,7 +1338,7 @@ window.elFinder = function(node, opts) {
 	if (this.transport.upload == 'iframe') {
 		this.transport.upload = $.proxy(this.uploads.iframe, this);
 	} else if (typeof(this.transport.upload) == 'function') {
-		this.dragUpload = !!this.options.dragUpload;
+		this.dragUpload = !!this.options.dragUploadAllow;
 	} else if (this.xhrUpload) {
 		this.transport.upload = $.proxy(this.uploads.xhr, this);
 		this.dragUpload = true;


### PR DESCRIPTION
Well, not really a typo, but an incorrent reference. dragUpload was used instead of dragUploadAllow.

This wasn't a problem on the first instance of elFinder on a page, since typeof(this.transport.upload) is "undefined", but on the second instance, it causes this.dragUpload to be set to false, when it should be set to true.
