### PR TITLE
Fix for multiple instances with different roots.

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -1819,8 +1819,8 @@ elFinder.prototype = {
 	
 	uploads : {
 		// upload transport using iframe
-		iframe : function(data) { 
-			var self   = this,
+		iframe : function(data, fm) { 
+			var self   = fm ? fm : this,
 				input  = data.input,
 				dfrd   = $.Deferred()
 					.fail(function(error) {
@@ -1834,8 +1834,8 @@ elFinder.prototype = {
 						self.trigger('upload', data);
 						data.sync && self.sync();
 					}),
-				name = 'iframe-'+this.namespace+(++this.iframeCnt),
-				form = $('<form action="'+this.uploadURL+'" method="post" enctype="multipart/form-data" encoding="multipart/form-data" target="'+name+'" style="display:none"><input type="hidden" name="cmd" value="upload" /></form>'),
+				name = 'iframe-'+self.namespace+(++self.iframeCnt),
+				form = $('<form action="'+self.uploadURL+'" method="post" enctype="multipart/form-data" encoding="multipart/form-data" target="'+name+'" style="display:none"><input type="hidden" name="cmd" value="upload" /></form>'),
 				msie = $.browser.msie,
 				// clear timeouts, close notification dialog, remove form/iframe
 				onload = function() {
@@ -1887,15 +1887,15 @@ elFinder.prototype = {
 			
 			cnt = input.files ? input.files.length : 1;
 			
-			form.append('<input type="hidden" name="'+(this.newAPI ? 'target' : 'current')+'" value="'+this.cwd().hash+'"/>')
+			form.append('<input type="hidden" name="'+(self.newAPI ? 'target' : 'current')+'" value="'+self.cwd().hash+'"/>')
 				.append('<input type="hidden" name="html" value="1"/>')
 				.append($(input).attr('name', 'upload[]'));
 			
-			$.each(this.options.onlyMimes||[], function(i, mime) {
+			$.each(self.options.onlyMimes||[], function(i, mime) {
 				form.append('<input type="hidden" name="mimes[]" value="'+mime+'"/>');
 			});
 			
-			$.each(this.options.customData, function(key, val) {
+			$.each(self.options.customData, function(key, val) {
 				form.append('<input type="hidden" name="'+key+'" value="'+val+'"/>');
 			});
 			
@@ -1905,8 +1905,8 @@ elFinder.prototype = {
 			return dfrd;
 		},
 		// upload transport using XMLHttpRequest
-		xhr : function(data) { 
-			var self   = this,
+		xhr : function(data, fm) { 
+			var self   = fm ? fm : this,
 				dfrd   = $.Deferred()
 					.fail(function(error) {
 						error && self.error(error);
@@ -1994,13 +1994,13 @@ elFinder.prototype = {
 			}, false);
 			
 			
-			xhr.open('POST', this.uploadURL, true);
+			xhr.open('POST', self.uploadURL, true);
 			formData.append('cmd', 'upload');
-			formData.append(this.newAPI ? 'target' : 'current', this.cwd().hash);
-			$.each(this.options.customData, function(key, val) {
+			formData.append(self.newAPI ? 'target' : 'current', self.cwd().hash);
+			$.each(self.options.customData, function(key, val) {
 				formData.append(key, val);
 			});
-			$.each(this.options.onlyMimes, function(i, mime) {
+			$.each(self.options.onlyMimes, function(i, mime) {
 				formData.append('mimes['+i+']', mime);
 			});
 			


### PR DESCRIPTION
The transport.upload method is called with two arguments, but doesn't accept two arguments. Adding the second argument lets multiple instances of elFinder with different root folders work on the same page. Before this change, the one loaded first would always receive any uploaded files.
