### PR TITLE
Constrain dialogs so that they can not be dragged outside of the document body

### DIFF
--- a/js/jquery.dialogelfinder.js
+++ b/js/jquery.dialogelfinder.js
@@ -34,7 +34,8 @@ $.fn.dialogelfinder = function(opts) {
 				.css('position', 'absolute')
 				.hide()
 				.appendTo('body')
-				.draggable({ handle : '.dialogelfinder-drag'})
+				.draggable({ handle : '.dialogelfinder-drag',
+					     containment : 'parent' })
 				.elfinder(opts)
 				.prepend(toolbar),
 			elfinder = node.elfinder('instance');

--- a/js/ui/dialog.js
+++ b/js/ui/dialog.js
@@ -40,7 +40,8 @@ $.fn.elfinderdialog = function(opts) {
 				.hide()
 				.append(self)
 				.appendTo(parent)
-				.draggable({ handle : '.ui-dialog-titlebar'})
+				.draggable({ handle : '.ui-dialog-titlebar',
+					     containment : $('body') })
 				.css({
 					width  : opts.width,
 					height : opts.height


### PR DESCRIPTION
Without this, it seems too easy to drag dialog boxes out of the window... and then they're gone!
