### PR TITLE
Include customData in params in url to file using the 'file' command

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -676,8 +676,16 @@ window.elFinder = function(node, opts) {
 		if (cwdOptions.url) {
 			return cwdOptions.url + $.map(this.path2array(hash), function(n) { return encodeURIComponent(n); }).slice(1).join('/')
 		}
-		
-		return this.options.url + (this.options.url.indexOf('?') === -1 ? '?' : '&') + (this.oldAPI ? 'cmd=open&current='+file.phash : 'cmd=file') + '&target=' + file.hash;
+
+		var params = $.extend({}, this.customData, {
+			cmd: 'file',
+			target: file.hash
+		});
+		if (this.oldAPI) {
+			params.cmd = 'open';
+			params.current = file.phash;
+		}
+		return this.options.url + (this.options.url.indexOf('?') === -1 ? '?' : '&') + $.param(params, true);
 	}
 	
 	/**


### PR DESCRIPTION
When generating the URL to a file, if there is no `info['url']` and no `cwdOptions.url`, elfinder generates a URL to the connector, with `cmd=file`.  Currently however, any `customData` is not included in the URL.  This is bad, since the internal state of the connector may depend on `customData`. E.g. `customData` may specify which volumes are mounted, or may contain authentication information.

This commit includes `customData` in the query parameters of the generated URL.
