### PR TITLE
Added Composer compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "studio-42/fm-elfinder",
+    "description": "File Manager for Web",
+    "keywords": ["jquery-ui", "file manager", "elfinder"],
+    "homepage": "https://github.com/Studio-42/elFinder",
+    "license": "BSD-3-Clause",
+    "authors": [
+        {"name": "Dmitry \"dio\" Levashov", "role": "Chief developer", "email": "dio@std42.ru"},
+        {"name": "Troex Nevelin", "role": "Maintainer", "email": "troex@fury.scancode.ru"},
+        {"name": "Alexey Sukhotin", "role":"Developer", "email": "strogg@yandex.ru"},
+        {"name": "Naoki Sawada", "role": "Developer", "email": "hypweb@gmail.com"}
+    ],
+    "require": {
+        "php": ">=5.2.0"
+    },
+    "include-path": [ "php/" ],
+    "target-dir": "FM/elfinder"
+}


### PR DESCRIPTION
Original composer.json is taken from helios-ag's fork. I just edited it back to your name.

This will add Composer compatibility.

Maybe you could also add this Project, after the Pull of the composer.json, to https://packagist.org, so there would be always an upstream version and no maintaining from helios-ag would be needed. 

If you then create the Packagist Git Hook on this repo your updates will automatically propagated.