### PR TITLE
Solution to issue #439

### DIFF
--- a/js/ui/contextmenu.js
+++ b/js/ui/contextmenu.js
@@ -27,8 +27,8 @@ $.fn.elfindercontextmenu = function(fm) {
 			
 			open = function(x, y) {
 				var win        = $(window),
-					width      = menu.outerWidth(),
-					height     = menu.outerHeight(),
+					width      = menu.outerWidth(false),
+					height     = menu.outerHeight(false),
 					wwidth     = win.width(),
 					wheight    = win.height(),
 					scrolltop  = win.scrollTop(),


### PR DESCRIPTION
Solution to the problem noted on issue #439.
jQuery 1.8 requires the arguments for .outerWidth(), or it will return the object itself.
