### PR TITLE
Menu item hover for jquery 1.9

### DIFF
--- a/js/ui/contextmenu.js
+++ b/js/ui/contextmenu.js
@@ -9,10 +9,7 @@ $.fn.elfindercontextmenu = function(fm) {
 	return this.each(function() {
 		var menu = $(this).addClass('ui-helper-reset ui-widget ui-state-default ui-corner-all elfinder-contextmenu elfinder-contextmenu-'+fm.direction)
 				.hide()
-				.appendTo('body')
-				.delegate('.elfinder-contextmenu-item', 'hover', function() {
-					$(this).toggleClass('ui-state-hover')
-				}),
+				.appendTo('body'),
 			subpos  = fm.direction == 'ltr' ? 'left' : 'right',
 			types = $.extend({}, fm.options.contextmenu),
 			tpl     = '<div class="elfinder-contextmenu-item"><span class="elfinder-button-icon {icon} elfinder-contextmenu-icon"/><span>{label}</span></div>',
@@ -22,6 +19,8 @@ $.fn.elfindercontextmenu = function(fm) {
 						e.stopPropagation();
 						e.stopPropagation();
 						callback();
+					}).hover(function(){
+						$(this).toggleClass('ui-state-hover');
 					})
 			},
 			
@@ -89,6 +88,8 @@ $.fn.elfindercontextmenu = function(fm) {
 											e.stopPropagation();
 											close();
 											cmd.exec(targets, variant[0]);
+										}).hover(function(){
+											$(this).toggleClass('ui-state-hover');
 										})
 								);
 							});


### PR DESCRIPTION
The delegate() method was not working with jquery 1.9. Assigning hover() methods to each menu item fixes this.
