### PR TITLE
Use filter() before 'destroy'

### DIFF
--- a/js/commands/resize.js
+++ b/js/commands/resize.js
@@ -364,8 +364,7 @@ elFinder.prototype.commands.resize = function() {
 					resizable = function(destroy) {
 						if ($.fn.resizable) {
 							if (destroy) {
-								rhandle.resizable()
-								rhandle.resizable('destroy');
+								rhandle.filter(':ui-resizable').resizable('destroy');
 								rhandle.hide();
 							}
 							else {
@@ -382,10 +381,8 @@ elFinder.prototype.commands.resize = function() {
 					croppable = function(destroy) {
 						if ($.fn.draggable && $.fn.resizable) {
 							if (destroy) {
-								rhandlec.resizable();
-								rhandlec.resizable('destroy');
-								rhandlec.draggable();
-								rhandlec.draggable('destroy');
+								rhandlec.filter(':ui-resizable').resizable('destroy');
+								rhandlec.filter(':ui-draggable').draggable('destroy');
 								basec.hide();
 							}
 							else {


### PR DESCRIPTION
Using filter(':ui-resizable') prevents errors in jquery 1.9
