### PR TITLE
Added caching on _checkArchivers to improve performance

### DIFF
--- a/php/elFinderVolumeLocalFileSystem.class.php
+++ b/php/elFinderVolumeLocalFileSystem.class.php
@@ -571,8 +571,12 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 	 * @return void
 	 **/
 	protected function _checkArchivers() {
+		if (isset($_SESSION['elFinder_archivers_cache']) && is_array($_SESSION['elFinder_archivers_cache'])) {
+			$this->archivers = $_SESSION['elFinder_archivers_cache'];
+			return;
+		}
 		if (!function_exists('exec')) {
-			$this->options['archivers'] = $this->options['archive'] = array();
+			$_SESSION['elFinder_archivers_cache'] = $this->archivers = $this->options['archivers'] = $this->options['archive'] = array();
 			return;
 		}
 		$arcs = array(
@@ -660,7 +664,7 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 			}
 		}
 		
-		$this->archivers = $arcs;
+		$_SESSION['elFinder_archivers_cache'] = $this->archivers = $arcs;
 	}
 
 	/**


### PR DESCRIPTION
When adding lots of mount points (around 50 local folders) I experienced very poor performance. Every action took around 6 seconds.
The bottleneck is the _checkArchivers method which is called on every mount.
I added a simple session-based caching. There might be better methods for this, but it improved speed by factor 10 for me (around 0.5 secs instead of 6 secs).
