### PR TITLE
Update elFinder.class.php

### DIFF
--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -155,7 +155,7 @@ class elFinder {
 	const ERROR_UPLOAD_FILE_SIZE  = 'errUploadFileSize';   // 'File exceeds maximum allowed size.'
 	const ERROR_UPLOAD_FILE_MIME  = 'errUploadMime';       // 'File type not allowed.'
 	const ERROR_UPLOAD_TRANSFER   = 'errUploadTransfer';   // '"$1" transfer error.'
-	// const ERROR_ACCESS_DENIED     = 'errAccess';
+	const ERROR_ACCESS_DENIED     = 'errAccess';           // 'Access denied' // eg. in command rm
 	const ERROR_NOT_REPLACE       = 'errNotReplace';       // Object "$1" already exists at this location and can not be replaced with object of another type.
 	const ERROR_SAVE              = 'errSave';
 	const ERROR_EXTRACT           = 'errExtract';


### PR DESCRIPTION
fixed: 
try to delete a file if deleting files are not allowed, get the following message:
Fatal error: Undefined class constant 'ERROR_ACCESS_DENIED' in **\php\elFinderVolumeDriver.class.php on line 1748

additional changes in elFinderVolumeDriver.class.php