### PR TITLE
2.x Custom columns in "list" view (Issue #559)

### DIFF
--- a/elfinder.src.html
+++ b/elfinder.src.html
@@ -217,7 +217,19 @@
 				// 	}
 				// }
 				// uiOptions : {
-				// 	toolbar : [['help']]
+				// 	toolbar : [['help']],
+				// 	cwd : {
+				//    listView : {
+				//      // columns to be displayed
+				//		// default settings are:
+				//      // columns : ['perm', 'date', 'size', 'kind'],
+				//      // extra columns can be displayed if your connector supports it:
+				//		columns : ['perm', 'date', 'size', 'kind', 'owner'],
+				//      // custom columns labels:
+				//		columnsCustomName : {
+				//			owner : 'Owner'
+				//		}
+				//	}
 				// }
 			})
 

--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -356,6 +356,13 @@ window.elFinder = function(node, opts) {
 		this.options.uiOptions.toolbar = opts.uiOptions.toolbar;
 	}
 
+	if (opts.uiOptions && opts.uiOptions.cwd && opts.uiOptions.cwd.listView && opts.uiOptions.cwd.listView.columns) {
+		this.options.uiOptions.cwd.listView.columns = opts.uiOptions.cwd.listView.columns;
+	}
+	if (opts.uiOptions && opts.uiOptions.cwd && opts.uiOptions.cwd.listView && opts.uiOptions.cwd.listView.columnsCustomName) {
+		this.options.uiOptions.cwd.listView.columnsCustomName = opts.uiOptions.cwd.listView.columnsCustomName;
+	}
+
 	$.extend(this.options.contextmenu, opts.contextmenu);
 
 	

--- a/js/elFinder.options.js
+++ b/js/elFinder.options.js
@@ -253,7 +253,21 @@ elFinder.prototype._options = {
 		},
 		cwd : {
 			// display parent folder with ".." name :)
-			oldSchool : false
+			oldSchool : false,
+			
+			// file info columns displayed
+			listView : {
+				// name is always displayed, cols are ordered
+				columns : ['perm', 'mod', 'size', 'kind'],
+				// override this if you want custom columns name
+				// example
+				// columnsCustomName : {
+				//		date : 'Last modification',
+				// 		kind : 'Mime type'
+				// }
+				columnsCustomName : {}
+									
+			}
 		}
 	},
 

--- a/js/elFinder.options.js
+++ b/js/elFinder.options.js
@@ -258,7 +258,7 @@ elFinder.prototype._options = {
 			// file info columns displayed
 			listView : {
 				// name is always displayed, cols are ordered
-				columns : ['perm', 'mod', 'size', 'kind'],
+				columns : ['perm', 'date', 'size', 'kind'],
 				// override this if you want custom columns name
 				// example
 				// columnsCustomName : {

--- a/js/ui/cwd.js
+++ b/js/ui/cwd.js
@@ -627,7 +627,7 @@ $.fn.elfindercwd = function(fm, options) {
 			msg = {
 				name : fm.i18n('name'),
 				perm : fm.i18n('perms'),
-				mod  : fm.i18n('modify'),
+				date : fm.i18n('modify'),
 				size : fm.i18n('size'),
 				kind : fm.i18n('kind')
 			},

--- a/js/ui/cwd.js
+++ b/js/ui/cwd.js
@@ -121,6 +121,15 @@ $.fn.elfindercwd = function(fm, options) {
 			
 			lastSearch = [],
 
+			customColsBuild = function() {
+				var customCols = '';
+				var columns = fm.options.uiOptions.cwd.listView.columns;
+				for (var i = 0; i < columns.length; i++) {
+					customCols += '<td>{' + columns[i] + '}</td>';
+				}
+				return customCols;
+			},
+
 			/**
 			 * File templates
 			 *
@@ -128,7 +137,7 @@ $.fn.elfindercwd = function(fm, options) {
 			 **/
 			templates = {
 				icon : '<div id="{hash}" class="'+clFile+' {permsclass} {dirclass} ui-corner-all" title="{tooltip}"><div class="elfinder-cwd-file-wrapper ui-corner-all"><div class="elfinder-cwd-icon {mime} ui-corner-all" unselectable="on" {style}/>{marker}</div><div class="elfinder-cwd-filename" title="{name}">{name}</div></div>',
-				row  : '<tr id="{hash}" class="'+clFile+' {permsclass} {dirclass}" title="{tooltip}"><td><div class="elfinder-cwd-file-wrapper"><span class="elfinder-cwd-icon {mime}"/>{marker}<span class="elfinder-cwd-filename">{name}</span></div></td><td>{perms}</td><td>{date}</td><td>{size}</td><td>{kind}</td></tr>'
+				row  : '<tr id="{hash}" class="'+clFile+' {permsclass} {dirclass}" title="{tooltip}"><td><div class="elfinder-cwd-file-wrapper"><span class="elfinder-cwd-icon {mime}"/>{marker}<span class="elfinder-cwd-filename">{name}</span></div></td>'+customColsBuild()+'</tr>',
 			},
 			
 			permsTpl = fm.res('tpl', 'perms'),
@@ -623,6 +632,19 @@ $.fn.elfindercwd = function(fm, options) {
 				kind : fm.i18n('kind')
 			},
 			
+			customColsNameBuild = function() {
+				var customColsName = '';
+				var columns = fm.options.uiOptions.cwd.listView.columns;
+				for (var i = 0; i < columns.length; i++) {
+					if (fm.options.uiOptions.cwd.listView.columnsCustomName[columns[i]] != null) {
+						customColsName +='<td>'+fm.options.uiOptions.cwd.listView.columnsCustomName[columns[i]]+'</td>';
+					} else {
+						customColsName +='<td>'+msg[columns[i]]+'</td>';
+					}
+				}
+				return customColsName;
+			},
+			
 			/**
 			 * Update directory content
 			 *
@@ -647,7 +669,7 @@ $.fn.elfindercwd = function(fm, options) {
 
 				wrapper[list ? 'addClass' : 'removeClass']('elfinder-cwd-wrapper-list');
 
-				list && cwd.html('<table><thead><tr class="ui-state-default"><td >'+msg.name+'</td><td>'+msg.perm+'</td><td>'+msg.mod+'</td><td>'+msg.size+'</td><td>'+msg.kind+'</td></tr></thead><tbody/></table>');
+				list && cwd.html('<table><thead><tr class="ui-state-default"><td >'+fm.i18n('name')+'</td>'+customColsNameBuild()+'</tr></thead><tbody/></table>');
 		
 				buffer = $.map(files, function(f) { return any || f.phash == phash ? f : null; });
 				

--- a/js/ui/cwd.js
+++ b/js/ui/cwd.js
@@ -669,7 +669,7 @@ $.fn.elfindercwd = function(fm, options) {
 
 				wrapper[list ? 'addClass' : 'removeClass']('elfinder-cwd-wrapper-list');
 
-				list && cwd.html('<table><thead><tr class="ui-state-default"><td >'+fm.i18n('name')+'</td>'+customColsNameBuild()+'</tr></thead><tbody/></table>');
+				list && cwd.html('<table><thead><tr class="ui-state-default"><td >'+msg.name+'</td>'+customColsNameBuild()+'</tr></thead><tbody/></table>');
 		
 				buffer = $.map(files, function(f) { return any || f.phash == phash ? f : null; });
 				


### PR DESCRIPTION
As described in issue #559 and #131 we need a setting to customize columns in listView.
This contribution let user choose columns to be displayed, order, and also display custom file infos provided with custom connectors.

You can test it with the following settings:

uiOptions : {
  cwd : {
   listView : {
     // columns to be displayed. default settings are:
     // columns : ['perm', 'date', 'size', 'kind'],

     // extra columns can be displayed if your connector supports it:
     columns : ['perm', 'date', 'size', 'kind', 'owner'],

     // custom columns labels:
      columnsCustomName : {
            owner : 'Owner'
      }
   }
}