### PR TITLE
Http Code on upload is 200 and can't be 201

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -2104,7 +2104,7 @@ elFinder.prototype = {
 				if (status > 500) {
 					return dfrd.reject('errResponse');
 				}
-				if (status != 200) {
+				if (status >= 400) { // @Pilooz 20x, 30x are not considered as http Errors. 40x and 500 are.
 					return dfrd.reject('errConnect');
 				}
 				if (xhr.readyState != 4) {


### PR DESCRIPTION
Hi,
I experimented a problem with a RESTful server side. When uploading some files, elFinder is waiting for a 200 http Code, and sends an error  'errConnect'  on other codes.
I think it should not send 'errConnect' message if the http Code response is 20x and neither 30x. 
For Example, a RESTful server side API should return 201 "Created" on a post request.
Please let me know if I am in the right way.

Cheers,