### PR TITLE
CORS & Custom header support

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -382,21 +382,21 @@ window.elFinder = function(node, opts) {
 	 **/
 	this.customData = $.isPlainObject(this.options.customData) ? this.options.customData : {};
 
-    /**
-     * Any custom headers to send across every ajax request
-     *
-     * @type Object
-     * @default {}
-     **/
-    this.customHeaders = $.isPlainObject(this.options.customHeaders) ? this.options.customHeaders : {};
+	/**
+	 * Any custom headers to send across every ajax request
+	 *
+	 * @type Object
+	 * @default {}
+	 **/
+	this.customHeaders = $.isPlainObject(this.options.customHeaders) ? this.options.customHeaders : {};
 
-    /**
-     * Any xhrFields to send across every ajax request
-     *
-     * @type Object
-     * @default {}
-     **/
-    this.xhrFields = $.isPlainObject(this.options.xhrFields) ? this.options.xhrFields : {};
+	/**
+	 * Any xhrFields to send across every ajax request
+	 *
+	 * @type Object
+	 * @default {}
+	 **/
+	this.xhrFields = $.isPlainObject(this.options.xhrFields) ? this.options.xhrFields : {};
 
 	/**
 	 * ID. Required to create unique cookie name


### PR DESCRIPTION
Added ability for the following:
- Passing custom headers
- Pass xhrFields

Usage:

```
elfinderOptions = {
    customHeaders: {'X-Requested-With': 'XMLHttpRequest'},
    xhrFields: {
            withCredentials: true
    },
    customData: anyCustomData,
    url : theURl,
    ...,
    uiOptions,
    ...
    and so on..
};

elf = $("#elfinder").elfinder(elfinderOptions);
```
