### PR TITLE
Fix Windows style exploding root path

### DIFF
--- a/php/elFinderVolumeLocalFileSystem.class.php
+++ b/php/elFinderVolumeLocalFileSystem.class.php
@@ -170,7 +170,9 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 		}
 			
 		$initial_slashes = (int) $initial_slashes;
-
+                
+                $path = str_replace(array('/', '\\'), '/', $path);
+                
 		$comps = explode('/', $path);
 		$new_comps = array();
 		foreach ($comps as $comp) {


### PR DESCRIPTION
If root path look like:
_C:\xampp\htdocs\frontend/../../backend/www_
code generate error: Root folder does not exist. 
Because 
```
$comps = explode('/', $path);
```
explode only unix separators, later in foreach it popup full first part _C:\xampp\htdocs\frontend._
In the end return only **../backend/www**

I fix this problem by replacing all windows separators **\** to unix, and other code work fine.