### PR TITLE
add md5sum in commands.info

### DIFF
--- a/elfinder.src.html
+++ b/elfinder.src.html
@@ -260,7 +260,8 @@
 						getfile : {
 							oncomplete : 'close',
 							folders : true
-						}
+						},
+						info : { md5sum : true } // false or none disable md5sum in commands.info
 					}
 				}).dialogelfinder('instance');
 			});

--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -363,6 +363,10 @@ window.elFinder = function(node, opts) {
 		this.options.uiOptions.toolbar = opts.uiOptions.toolbar;
 	}
 
+	if (opts.commandsOptions && opts.commandsOptions.info && opts.commandsOptions.info.md5sum) {
+		this.options.commandsOptions.info.md5sum = opts.commandsOptions.info.md5sum;
+	}
+
 	$.extend(this.options.contextmenu, opts.contextmenu);
 
 	

--- a/js/elFinder.options.js
+++ b/js/elFinder.options.js
@@ -184,9 +184,10 @@ elFinder.prototype._options = {
 			]
 		},
 		// "info" command options.
-		info : {nullUrlDirLinkSelf : true},
-		
-
+		info : {
+			nullUrlDirLinkSelf : true,
+			md5sum : false
+		},
 		help : {view : ['about', 'shortcuts', 'help']}
 	},
 	

--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -55,6 +55,7 @@ class elFinder {
 		'tmb'       => array('targets' => true),
 		'file'      => array('target' => true, 'download' => false),
 		'size'      => array('targets' => true),
+		'md5sum'    => array('target' => true),
 		'mkdir'     => array('target' => true, 'name' => true),
 		'mkfile'    => array('target' => true, 'name' => true, 'mimes' => false),
 		'rm'        => array('targets' => true),
@@ -783,6 +784,28 @@ class elFinder {
 		return array('size' => $size);
 	}
 	
+	/**
+	 * get md5sum
+	 *
+	 * @param  array  command arguments
+	 * @return array
+	 * @author gabriel.rota@gmail.com
+	 **/
+	protected function md5sum($args) {
+		$size = 0;
+		
+		$target = $args['target'];
+		if (($volume = $this->volume($target)) == false
+		|| ($file = $volume->file($target)) == false
+		|| !$file['read']) {
+			return array('error' => $this->error(self::ERROR_OPEN, '#'.$target));
+		}
+		
+		$md5sum = $volume->md5sum($target) ;
+		
+		return array('md5sum' => $md5sum);
+	}
+
 	/**
 	 * Create directory
 	 *

--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -1182,6 +1182,22 @@ abstract class elFinderVolumeDriver {
 	}
 	
 	/**
+	 * md5sum from file
+	 *
+	 * @param  string   file hash
+	 * @return string
+	 * @author gabriel.rota@gmail.com
+	 **/
+	public function md5sum($hash) {
+		if (($file = $this->file($hash)) == false
+		|| $file['mime'] == 'directory') {
+			return false;
+		}
+		
+		return $this->_md5sum($this->decode($hash), 'rb');
+	}
+	
+	/**
 	 * Close file pointer
 	 *
 	 * @param  Resource  $fp   file pointer

--- a/php/elFinderVolumeLocalFileSystem.class.php
+++ b/php/elFinderVolumeLocalFileSystem.class.php
@@ -411,6 +411,17 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 	}
 	
 	/**
+	 * md5sum of file
+	 *
+	 * @param  string  $path  file path
+	 * @return string
+	 * @author gabriel.rota@gmail.com
+	 **/
+	protected function _md5sum($path) {
+		return md5_file($path);
+	}
+	
+	/**
 	 * Close opened file
 	 *
 	 * @param  resource  $fp  file pointer


### PR DESCRIPTION
Enabled md5sum value for file into info dialog.
Disabled by default.
Example for enabling:
$('#finder').elfinder({ commandsOptions : { info : { md5sum : true } } });