### PR TITLE
regression from f38a3787 : we should use variable url 

### DIFF
--- a/js/commands/open.js
+++ b/js/commands/open.js
@@ -85,7 +85,7 @@ elFinder.prototype.commands.open = function() {
 			}
 			
 			var form = document.createElement("form");
-			form.action = fm.options.url;
+			form.action = url;
 			form.method = 'POST';
 			form.target = 'new_window';
 			form.style.display = 'none';


### PR DESCRIPTION
regression from f38a3787 : we should use variable url which was set a few lines upper. 
Otherwise elfinder always opens files through connector 'file' command, even if we want to open files directly from remote URL.