### PR TITLE
[connector:php] new volume options `encoding`, `locale`

### DIFF
--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -25,7 +25,19 @@ class elFinder {
 	 **/
 	protected $volumes = array();
 	
+	/**
+	 * Network mount drivers
+	 * 
+	 * @var array
+	 */
 	public static $netDrivers = array();
+	
+	/**
+	 * elFinder global locale
+	 * 
+	 * @var string
+	 */
+	public static $locale = '';
 	
 	/**
 	 * Session key of net mount volumes
@@ -223,7 +235,11 @@ class elFinder {
 		$this->netVolumesSessionKey = !empty($opts['netVolumesSessionKey'])? $opts['netVolumesSessionKey'] : 'elFinderNetVolumes';
 		$this->callbackWindowURL = (isset($opts['callbackWindowURL']) ? $opts['callbackWindowURL'] : '');
 		
-		setlocale(LC_ALL, !empty($opts['locale']) ? $opts['locale'] : 'en_US.UTF-8');
+		// setlocale and global locale regists to elFinder::locale
+		self::$locale = !empty($opts['locale']) ? $opts['locale'] : 'en_US.UTF-8';
+		if (false === @setlocale(LC_ALL, self::$locale)) {
+			self::$locale = setlocale(LC_ALL, '');
+		}
 
 		// bind events listeners
 		if (!empty($opts['bind']) && is_array($opts['bind'])) {


### PR DESCRIPTION
for support non UTF-8 server

ref: Studio-42#443, Studio-42#446, Studio-42#466, Studio-42#570, Studio-42#601, Studio-42#701, Studio-42#911

This solution would correct these related problems. It would become possible to be to designate `encoding`, `locale` of a volume option and connect non-UTF-8 to a server.
