### PR TITLE
Check if working path is normal path before delete

### DIFF
--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -1754,8 +1754,10 @@ abstract class elFinderVolumeDriver {
 		}
 		
 		$work_path = $this->getWorkFile($path);
-		if ($path !== $work_path && (!$work_path || !is_writable($work_path))) {
-			is_file($work_path) && @unlink($work_path);
+		if (!$work_path || !is_writable($work_path)) {
+			if ($work_path && $path !== $work_path && is_file($work_path)) {
+				@unlink($work_path);
+			}
 			return false;
 		}
 


### PR DESCRIPTION
$work_path could also be false, when creating failed.
Don't delete when the local file is the original file.