### PR TITLE
[volume:LocalFileSystem] Option `defaults` does not work without `accessControl`

### DIFF
--- a/php/elFinderVolumeLocalFileSystem.class.php
+++ b/php/elFinderVolumeLocalFileSystem.class.php
@@ -314,8 +314,10 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 		
 		$stat['mime']  = $dir ? 'directory' : $this->mimetype($path);
 		$stat['ts']    = filemtime($path);
-		$stat['read']  = is_readable($path);
-		$stat['write'] = is_writable($path);
+		//logical rights first
+		$stat['read'] = is_readable($path)?null:false;
+		$stat['write'] = is_writable($path)?null:false;
+
 		if ($stat['read']) {
 			$stat['size'] = $dir ? 0 : $size;
 		}


### PR DESCRIPTION
Сейчас доступность для записи чтения определяется на физическом уровне. При этом игнорируются заданные в конфиге roota значения defaults. Предлагаю в случае доступности чтения/записи возвращать null, a не true, чтобы в дальнейшем (если физическая запись доступна) можно было закрыть её конфигом root->defaults. Иначе 2164 и 2165 строки не присвают значения из конфига root->defaults.