### PR TITLE
Fix edge case when the root is / and no alias is provided.

### DIFF
--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -721,6 +721,11 @@ abstract class elFinderVolumeDriver {
 		}
 
 		$this->rootName = empty($this->options['alias']) ? $this->_basename($this->root) : $this->options['alias'];
+
+                // This get's triggered if $this->root == '/' and alias is empty.
+                // Maybe modify _basename instead?
+                if (empty($this->rootName)) $this->rootName = $this->separator;
+
 		$root = $this->stat($this->root);
 		
 		if (!$root) {


### PR DESCRIPTION
While playing around I was having problems when I set the root to '/' and tracked it down to the rootName being set to '' due to the fact that basename (unsurprisingly) returns '' for '/'.  I think this is the best place for this change but it could be pulled into _basename in elFinderVolumeLocalFileSystem.class.php.  But that might break otherthings potentially.