### PR TITLE
fix _inpath when root is /

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ elFinderVolumeSVN.class.php
 connector-svn.php
 node_modules
 connector.php
+css/*.full.css
+css/*.min.css
+js/*.full.js
+js/*.min.js

--- a/php/elFinderVolumeLocalFileSystem.class.php
+++ b/php/elFinderVolumeLocalFileSystem.class.php
@@ -248,7 +248,8 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 		$real_path = realpath($path);
 		$real_parent = realpath($parent);
 		if ($real_path && $real_parent) {
-			return $real_path === $real_parent || strpos($real_path, $real_parent.DIRECTORY_SEPARATOR) === 0;
+			if (substr($real_parent, -1) != '/') $real_parent .= DIRECTORY_SEPARATOR;
+			return $real_path === $real_parent || strpos($real_path, $real_parent) === 0;
 		}
 		return false;
 	}

--- a/php/elFinderVolumeLocalFileSystem.class.php
+++ b/php/elFinderVolumeLocalFileSystem.class.php
@@ -248,7 +248,8 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 		$real_path = realpath($path);
 		$real_parent = realpath($parent);
 		if ($real_path && $real_parent) {
-			if (substr($real_parent, -1) != '/') $real_parent .= DIRECTORY_SEPARATOR;
+			if (substr($real_parent, -1) != DIRECTORY_SEPARATOR )
+				 $real_parent .= DIRECTORY_SEPARATOR;
 			return $real_path === $real_parent || strpos($real_path, $real_parent) === 0;
 		}
 		return false;


### PR DESCRIPTION
When / is the root, the '_inpath' function would compare /foo to // and thus fail.  This change detects if the path ends in a / and does not add an addition / in that situation.

I also added the min and full .js and .css files that are created during the build process to the .gitignore file.