### PR TITLE
return ownership (uid/gid) and mode (permissions)

### DIFF
--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -70,7 +70,8 @@ class elFinder {
 		'info'      => array('targets' => true),
 		'dim'       => array('target' => true),
 		'resize'    => array('target' => true, 'width' => true, 'height' => true, 'mode' => false, 'x' => false, 'y' => false, 'degree' => false),
-		'netmount'  => array('protocol' => true, 'host' => true, 'path' => false, 'port' => false, 'user' => true, 'pass' => true, 'alias' => false, 'options' => false)
+		'netmount'  => array('protocol' => true, 'host' => true, 'path' => false, 'port' => false, 'user' => true, 'pass' => true, 'alias' => false, 'options' => false),
+		'chmod'     => array('target' => true, 'mode' => true)
 	);
 	
 	/**
@@ -277,7 +278,6 @@ class elFinder {
 		$cmds = $cmd == '*'
 			? array_keys($this->commands)
 			: array_map('trim', explode(' ', $cmd));
-		
 		foreach ($cmds as $cmd) {
 			if ($cmd) {
 				if (!isset($this->listeners[$cmd])) {
@@ -901,6 +901,31 @@ class elFinder {
 			}
 		}
 
+		return $result;
+	}
+
+	/**
+	 * chmod
+	 *
+	 * @param array  command arguments
+	 * @return array
+	 * @author David Bartle
+	 **/
+	protected function chmod($args) {
+		$target = $args['target'];
+		$mode   = $args['mode'];
+
+		if (($volume = $this->volume($target)) == false) {
+			$result['warning'] = $this->error(self::ERROR_RM, '#'.$target, self::ERROR_FILE_NOT_FOUND);
+			return $result;
+		}
+
+		if (($file = $volume->chmod($target, $mode)) === false) {
+			$result['warning'] = $this->error($volume->error());
+			return $result;
+		}
+
+		$result['chmod'] = $file;
 		return $result;
 	}
 	

--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -586,7 +586,7 @@ abstract class elFinderVolumeDriver {
 			return $this->setError(elFinder::ERROR_FILE_NOT_FOUND);
 		}
 
-		if (!$file['chmod']) {
+		if (!$file['write']) {
 			return $this->setError(elFinder::ERROR_PERM_DENIED);
 		}
 

--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -568,6 +568,36 @@ abstract class elFinderVolumeDriver {
 			'imgLib'     => $this->imgLib
 		);
 	}
+
+	/**
+	 * chmod a file or folder
+	 *
+	 * @param  string   $hash    file or folder hash to chmod
+	 * @param  string   $mode    octal string representing new permissions
+	 * @return array|false
+	 * @author David Bartle
+	 **/
+	public function chmod($hash, $mode) {
+		if ($this->commandDisabled('chmod')) {
+			return $this->setError(elFinder::ERROR_PERM_DENIED);
+		}
+
+		if (!($file = $this->file($hash))) {
+			return $this->setError(elFinder::ERROR_FILE_NOT_FOUND);
+		}
+
+		if (!$file['chmod']) {
+			return $this->setError(elFinder::ERROR_PERM_DENIED);
+		}
+
+		$path = $this->decode($hash);
+
+		$this->_chmod($path,$mode);
+
+		$this->clearcache();
+
+		return ($file = $this->stat($path)) ? $file : $this->setError(elFinder::ERROR_FILE_NOT_FOUND);
+	}
 	
 	/**
 	 * "Mount" volume.
@@ -3662,5 +3692,16 @@ abstract class elFinderVolumeDriver {
 	 * @author Alexey Sukhotin
 	 **/
 	abstract protected function _checkArchivers();
+
+	/**
+	 * Change file mode (chmod)
+	 *
+	 * @param  string  $path  file path
+	 * @param  string  $mode  octal string such as '0755'
+	 * @return bool
+	 * @author David Bartle,
+	 **/
+	abstract protected function _chmod($path, $mode);
+
 	
 } // END class

--- a/php/elFinderVolumeFTP.class.php
+++ b/php/elFinderVolumeFTP.class.php
@@ -907,6 +907,16 @@ class elFinderVolumeFTP extends elFinderVolumeDriver {
 	}
 
 	/**
+	 * chmod availability
+	 *
+	 * @return void
+	 **/
+	protected function _chmod($path, $mode) {
+		$modeOct = is_string($mode) ? octdec($mode) : octdec(sprintf("%04o",$mode));
+		@ftp_chmod($this->connect, $modeOct, $path);
+	}
+
+	/**
 	 * Unpack archive
 	 *
 	 * @param  string  $path  archive path

--- a/php/elFinderVolumeLocalFileSystem.class.php
+++ b/php/elFinderVolumeLocalFileSystem.class.php
@@ -126,7 +126,8 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 					'read'    => false,
 					'write'   => false,
 					'locked'  => true,
-					'hidden'  => true
+					'hidden'  => true,
+					'chmod'   => false
 			);
 		}
 	}
@@ -325,6 +326,7 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 				$stat['mime']  = 'symlink-broken';
 				$stat['read']  = false;
 				$stat['write'] = false;
+				$stat['chmod'] = 0;
 				$stat['size']  = 0;
 				return $stat;
 			}
@@ -351,6 +353,13 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 		//logical rights first
 		$stat['read'] = is_readable($path)? null : false;
 		$stat['write'] = is_writable($path)? null : false;
+
+		if( function_exists('posix_geteuid') && posix_geteuid() == $uid ) {
+			$stat['chmod'] = 1;
+		}
+		else {
+			$stat['chmod'] = 0;
+		}
 
 		if (is_null($stat['read'])) {
 			$stat['size'] = $dir ? 0 : $size;
@@ -641,6 +650,16 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 	protected function _checkArchivers() {
 		$this->archivers = $this->getArchivers();
 		return;
+	}
+
+	/**
+	 * chmod availability
+	 *
+	 * @return void
+	 **/
+	protected function _chmod($path, $mode) {
+		$modeOct = is_string($mode) ? octdec($mode) : octdec(sprintf("%04o",$mode));
+		chmod($path, $modeOct);
 	}
 
 	/**

--- a/php/elFinderVolumeLocalFileSystem.class.php
+++ b/php/elFinderVolumeLocalFileSystem.class.php
@@ -1,5 +1,34 @@
 <?php
 
+function unixmode_readable($mode) {
+
+	$friendly = '';
+
+	// u
+	$friendly .= (($mode & 0x0100) ? 'r' : '-');
+	$friendly .= (($mode & 0x0080) ? 'w' : '-');
+	$friendly .= (($mode & 0x0040) ?
+					(($mode & 0x0800) ? 's' : 'x' ) :
+					(($mode & 0x0800) ? 'S' : '-'));
+
+	// g
+	$friendly .= (($mode & 0x0020) ? 'r' : '-');
+	$friendly .= (($mode & 0x0010) ? 'w' : '-');
+	$friendly .= (($mode & 0x0008) ?
+					(($mode & 0x0400) ? 's' : 'x' ) :
+					(($mode & 0x0400) ? 'S' : '-'));
+
+	// a
+	$friendly .= (($mode & 0x0004) ? 'r' : '-');
+	$friendly .= (($mode & 0x0002) ? 'w' : '-');
+	$friendly .= (($mode & 0x0001) ?
+					(($mode & 0x0200) ? 't' : 'x' ) :
+					(($mode & 0x0200) ? 'T' : '-'));
+
+	return $friendly;
+
+}
+
 /**
  * elFinder driver for local filesystem.
  *
@@ -357,9 +386,10 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 		}
 
 		$stat['perms'] = array();
-		$stat['perms']['umask'] = sprintf("%04o", @umask());
-		$stat['perms']['octal'] = sprintf("%04o", ($mode & 007777));
-		$stat['perms']['mode']  = $mode;
+		$stat['perms']['umask']    = sprintf("%04o", @umask());
+		$stat['perms']['octal']    = sprintf("%04o", ($mode & 007777));
+		$stat['perms']['mode']     = $mode;
+		$stat['perms']['readable'] = unixmode_readable($mode);
 
 		$stat['ownership'] = array();
 

--- a/php/elFinderVolumeLocalFileSystem.class.php
+++ b/php/elFinderVolumeLocalFileSystem.class.php
@@ -126,8 +126,7 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 					'read'    => false,
 					'write'   => false,
 					'locked'  => true,
-					'hidden'  => true,
-					'chmod'   => false
+					'hidden'  => true
 			);
 		}
 	}
@@ -326,7 +325,6 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 				$stat['mime']  = 'symlink-broken';
 				$stat['read']  = false;
 				$stat['write'] = false;
-				$stat['chmod'] = 0;
 				$stat['size']  = 0;
 				return $stat;
 			}
@@ -353,13 +351,6 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 		//logical rights first
 		$stat['read'] = is_readable($path)? null : false;
 		$stat['write'] = is_writable($path)? null : false;
-
-		if( function_exists('posix_geteuid') && posix_geteuid() == $uid ) {
-			$stat['chmod'] = 1;
-		}
-		else {
-			$stat['chmod'] = 0;
-		}
 
 		if (is_null($stat['read'])) {
 			$stat['size'] = $dir ? 0 : $size;

--- a/php/elFinderVolumeLocalFileSystem.class.php
+++ b/php/elFinderVolumeLocalFileSystem.class.php
@@ -333,8 +333,15 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 			$path  = $target;
 			$lstat = lstat($path);
 			$size  = $lstat['size'];
+			$mode  = $lstat['mode'];
+			$uid   = $lstat['uid'];
+			$gid   = $lstat['gid'];
 		} else {
-			$size = @filesize($path);
+			$corestat = stat($path);
+			$size	 = @filesize($path);
+			$mode	 = $corestat['mode'];
+			$uid	  = $corestat['uid'];
+			$gid	  = $corestat['gid'];
 		}
 		
 		$dir = is_dir($path);
@@ -348,6 +355,21 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 		if (is_null($stat['read'])) {
 			$stat['size'] = $dir ? 0 : $size;
 		}
+
+		$stat['perms'] = array();
+		$stat['perms']['umask'] = sprintf("%04o", @umask());
+		$stat['perms']['octal'] = sprintf("%04o", ($mode & 007777));
+		$stat['perms']['mode']  = $mode;
+
+		$stat['ownership'] = array();
+
+		$stat['ownership']['owner'] = $uid;
+		$owner_info = function_exists('posix_getpwuid') ? @posix_getpwuid($uid) : array( 'name' => '' );
+		$stat['ownership']['ownerName'] = $owner_info['name'];
+
+		$group_info = function_exists('posix_getgrgid') ? @posix_getgrgid($gid) : array( 'name' => '' );
+		$stat['ownership']['group'] = $gid;
+		$stat['ownership']['groupName'] = $group_info['name'];
 		
 		return $stat;
 	}

--- a/php/elFinderVolumeMySQL.class.php
+++ b/php/elFinderVolumeMySQL.class.php
@@ -906,6 +906,15 @@ class elFinderVolumeMySQL extends elFinderVolumeDriver {
 	}
 
 	/**
+	 * chmod implementation
+	 *
+	 * @return void
+	 **/
+	protected function _chmod($path, $mode) {
+		return;
+	}
+
+	/**
 	 * Unpack archive
 	 *
 	 * @param  string  $path  archive path


### PR DESCRIPTION
I'm not sure what the process is to add information to the file structure returned when listing folders.

Ultimately, I would love to add in ownership and permission information to the structure returned when getting file listings -- just in the connector, not expecting it in the UI.

I also added a 'chmod' command which can be called like so:

connector.php?cmd=chmod&target=HASH&mode=0755

This will error out if the 'chmod' command is disabled, or if the effective UID of the process does not have permission to perform the chmod, or if the file/directory doesn't exist.

It returns a fresh stat of the file/directory if successful.

Did I go about this the right way?  If not, any suggestions or concerns with this approach?

```
{
    "name"   : "Images",             // (String) name of file/dir. Required
    "hash"   : "l0_SW1hZ2Vz",        // (String) hash of current file/dir path, first symbol must be letter, symbols before _underline_ - volume id, Required. 
    "phash"  : "l0_Lw",              // (String) hash of parent directory. Required except roots dirs.
    "mime"   : "directory",          // (String) mime type. Required.
    "ts"     : 1334163643,           // (Number) file modification time in unix timestamp. Required.
    "date"   : "30 Jan 2010 14:25",  // (String) last modification time (mime). Depricated but yet supported. Use ts instead.
    "size"   : 12345,                // (Number) file size in bytes
    "dirs"   : 1,                    // (Number) Only for directories. Marks if directory has child directories inside it. 0 (or not set) - no, 1 - yes. Do not need to calculate amount.
    "read"   : 1,                    // (Number) is readable
    "write"  : 1,                    // (Number) is writable
    "locked" : 0,                    // (Number) is file locked. If locked that object cannot be deleted,  renamed or moved
    "tmb"    : 'bac0d45b625f8d4633435ffbd52ca495.png' // (String) Only for images. Thumbnail file name, if file do not have thumbnail yet, but it can be generated than it must have value "1"
    "alias"  : "files/images",       // (String) For symlinks only. Symlink target path.
    "thash"  : "l1_c2NhbnMy",        // (String) For symlinks only. Symlink target hash.
    "dim"    : "640x480",            // (String) For images - file dimensions. Optionally.
    "volumeid" : "l1_",              // (String) Volume id. For root dir only.

    // my additions to LocalVolume driver

    "chmod" : 1,                      // (Number) will chmod work on this file or folder?
    "perms" : {
        "umask" : "0022",            // (String) the umask for the current running process
        "octal" : "0700",            // (String) what you would expect to pass to 'chmod'
        "mode"  : 16832,             // (Number) raw mode from stat or lstat call
    },
    "ownership" : {
        "owner"     : 1234,          // (Number) uid of file from stat or lstat call
        "ownerName" : "foobar"       // (String) the posix user name for that uid
        "group"     : 1234,          // (Number) gid of file from stat or lstat call - blank if posix_getpwuid is not available
        "groupName" : "foobar"       // (String) the posix group name for that gid - blank if posix_getgwgid is not available
    },
}
```