### PR TITLE
Use json_encode instead of serialize

### DIFF
--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -245,7 +245,7 @@ class elFinder {
 		self::$sessionCacheKey = !empty($opts['sessionCacheKey']) ? $opts['sessionCacheKey'] : 'elFinderCaches';
 		
 		// check session cache
-		$_optsMD5 = md5(serialize($opts['roots']));
+		$_optsMD5 = md5(json_encode($opts['roots']));
 		if (! isset($_SESSION[self::$sessionCacheKey]) || $_SESSION[self::$sessionCacheKey]['_optsMD5'] !== $_optsMD5) {
 			$_SESSION[self::$sessionCacheKey] = array(
 				'_optsMD5' => $_optsMD5


### PR DESCRIPTION
Using `serialize()` causes errors for Closures, see https://github.com/barryvdh/elfinder-builds/commit/e8357274137d60a6205d31df4840c8a1713b60c3#commitcomment-11854093 and https://github.com/barryvdh/elfinder-flysystem-driver/issues/10

> php/elFinder.class.php line 248
"Serialization of 'Closure' is not allowed"

json_encode should also be faster anyways. http://stackoverflow.com/questions/2254220/php-best-way-to-md5-multi-dimensional-array