### PR TITLE
Update info.js

### DIFF
--- a/js/commands/info.js
+++ b/js/commands/info.js
@@ -151,6 +151,18 @@ elFinder.prototype.commands.info = function() {
 			content.push(row.replace(l, msg.modify).replace(v, fm.formatDate(file)));
 			content.push(row.replace(l, msg.perms).replace(v, fm.formatPermissions(file)));
 			content.push(row.replace(l, msg.locked).replace(v, file.locked ? msg.yes : msg.no));
+
+			// Add custom info fields
+			if (o.custom) $.each(o.custom, function(name, details) {
+				if (!details.mimes || $.inArray(file.mime, details.mimes) >= 0) {
+					// Add to the content
+					content.push(row.replace(l, details.label).replace(v , details.tpl));
+					// Add to @msg map
+					msg[name] = fm.i18n(name);
+					// Register the action
+					details.action(file, fm, dialog, msg);
+				}
+			});
 		} else {
 			view  = view.replace('{class}', 'elfinder-cwd-icon-group');
 			title = tpl.groupTitle.replace('{items}', msg.items).replace('{num}', cnt);


### PR DESCRIPTION
[Adding extra fields to the properties dialog](https://github.com/Studio-42/elFinder/wiki/Adding-file-description-to-Properties-dialog) #1057 currently involves editing the source code in `js/commands/info.js`. This means any changes that a user makes here are incredibly brittle, as they need to be added and rebuilt into any new elFinder updates.

This change will allow users to add extra properties from the elFinder client configuration on the `commandsOptions` object:

```javascript
// In the configuration object:
commandsOptions : {
  info : {
    // Custom fields
    custom : {
      // Description field
      desc : {
        // Label
        label : 'Description',

        // Template
        tpl : '<div id="elfinder-fm-file-desc"></div>',

        // Restricts to mimetypes
        mimes : ['text/html'],

        // Request that asks for the description and sets the field
        action : function(file, filemanager, dialog) {
          filemanager.request({
            data : { cmd : 'desc', target: file.hash },
            preventDefault: true,
          })
          .done(function(data) {
            var $desc = dialog.find('#elfinder-fm-file-desc');
            $desc.html(data.desc);
          });
        },
      }
    }
  }
},
```

This protects users who want to add custom fields from digging around in the Javascript source code to make those changes.