### PR TITLE
Update tree.js

### DIFF
--- a/js/ui/tree.js
+++ b/js/ui/tree.js
@@ -180,7 +180,7 @@ $.fn.elfindertree = function(fm, opts) {
 			 */
 			replace = {
 				id          : function(dir) { return fm.navHash2Id(dir.hash) },
-				cssclass    : function(dir) { return (fm.UA.Touch ? 'elfinder-touch ' : '')+(dir.phash ? '' : root)+' '+navdir+' '+fm.perms2class(dir)+' '+(dir.dirs && !dir.link ? collapsed : '') + (opts.cssClass ? ' ' + opts.cssClass(dir) : ''); },
+				cssclass    : function(dir) { return (fm.UA.Touch ? 'elfinder-touch ' : '')+(dir.phash ? '' : root)+' '+navdir+' '+fm.perms2class(dir)+' '+(dir.dirs && !dir.link ? collapsed : '') + (opts.getClass ? ' ' + opts.getClass(dir) : ''); },
 				permissions : function(dir) { return !dir.read || !dir.write ? ptpl : ''; },
 				symlink     : function(dir) { return dir.alias ? stpl : ''; },
 				style       : function(dir) { return dir.icon ? 'style="background-image:url(\''+dir.icon+'\')"' : ''; }

--- a/js/ui/tree.js
+++ b/js/ui/tree.js
@@ -180,7 +180,7 @@ $.fn.elfindertree = function(fm, opts) {
 			 */
 			replace = {
 				id          : function(dir) { return fm.navHash2Id(dir.hash) },
-				cssclass    : function(dir) { return (fm.UA.Touch ? 'elfinder-touch ' : '')+(dir.phash ? '' : root)+' '+navdir+' '+fm.perms2class(dir)+' '+(dir.dirs && !dir.link ? collapsed : ''); },
+				cssclass    : function(dir) { return (fm.UA.Touch ? 'elfinder-touch ' : '')+(dir.phash ? '' : root)+' '+navdir+' '+fm.perms2class(dir)+' '+(dir.dirs && !dir.link ? collapsed : '') + (opts.cssClass ? ' ' + opts.cssClass(dir) : ''); },
 				permissions : function(dir) { return !dir.read || !dir.write ? ptpl : ''; },
 				symlink     : function(dir) { return dir.alias ? stpl : ''; },
 				style       : function(dir) { return dir.icon ? 'style="background-image:url(\''+dir.icon+'\')"' : ''; }


### PR DESCRIPTION
There is currently no way to add custom, directory-dependent CSS classes to the navbar icons. This change will allow this to be done on the elFinder client configuration object:

```javascript
// In the configuration object:
uiOptions : {
  tree : {
    cssClass: function(directory) {
      // This adds the directory's name (lowercase) as a CSS class
      return directory.name.toLowerCase();
    }
  }
},
// ...
```

Thus a client can style individual navbar directories based on the directory data (e.g. a 'Pictures' icon for a pictures folder, a 'Videos' icon for a videos folder, etc).

This also means that if the server (volume driver) provides custom data to the directory, that too can be used for styling: e.g. if the server gives the `directory` the property `foo`, a style can be added that is dependent on the value of `directory.foo`.