### PR TITLE
Update elFinder.js

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -3004,6 +3004,8 @@ elFinder.prototype = {
 		var locHash = window.location.hash;
 		if (locHash && locHash.match(/^#elf_/)) {
 			return locHash.replace(/^#elf_/, '');
+		} else if (this.options.startDir) {
+			return this.options.startDir;
 		} else {
 			return this.lastDir();
 		}

--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -3004,8 +3004,8 @@ elFinder.prototype = {
 		var locHash = window.location.hash;
 		if (locHash && locHash.match(/^#elf_/)) {
 			return locHash.replace(/^#elf_/, '');
-		} else if (this.options.startDir) {
-			return this.options.startDir;
+		} else if (this.options.startPathHash) {
+			return this.options.startPathHash;
 		} else {
 			return this.lastDir();
 		}


### PR DESCRIPTION
Currently, the only way to set the starting directory from the client side is by providing a [hash](https://github.com/Studio-42/elFinder/wiki/Client-Server-API-2.0#file-paths-hashes) in the elFinder url:

```
path/to/elfinder.html?someUrlParametersThen#elf_hashOfThePath
```

When integrating a file browser with CKEditor, CKEditor automatically appends a `CKEditorFuncNum` and `langCode` property to the end of the `ckconfig.filebrowserBrowseUrl` url:

```
path/to/elfinder.html?someUrlParametersThen#elf_hashOfThePath&CKEditorFuncNum=1&langCode=en
```

This forms an invalid url and makes it impossible to set the elFinder starting directory from the client side with CKEditor. The proposed change allows users to do so by having an optional `startDir` property on the elFinder options object:

```javascript
{
  // ...
  startDir: 'hashOfThePath',
  // ...
}
```

An identical functionality exists for the [server connector](https://github.com/Studio-42/elFinder/wiki/Connector-configuration-options-2.1#startPath), but it is called `startPath`. If these changes are integrated, should the client property name be changed to `startPath` as well?