### PR TITLE
Change connector recommendation to minimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Installation
       $ git clone https://github.com/Studio-42/elFinder.git
       ```
 
- 2. Rename `/php/connector.php-dist` to `/php/connector.php`
+ 2. Rename `/php/connector.minimal.php-dist` to `/php/connector.minimal.php`
  3. Load `/elfinder.src.html` in your browser to run elFinder
 
 Downloads

--- a/elfinder.src.html
+++ b/elfinder.src.html
@@ -117,7 +117,7 @@
 		$(function() {
 			$('#elfinder').elfinder({
 				// Connector URL
-				url : 'php/connector.php',
+				url : 'php/connector.minimal.php',
 
 				// Callback when a file is double-clicked
 				getFileCallback : function(file) {


### PR DESCRIPTION
After some quick testing, its easiest for people to get started with the minimal connector even for the source version of elFinder, so I've changed that in the installation guide in the readme.