### PR TITLE
Make elFinderConnector::input_filter() protected

### DIFF
--- a/php/elFinderConnector.class.php
+++ b/php/elFinderConnector.class.php
@@ -140,7 +140,7 @@ class elFinderConnector {
 	 * @return mixed
 	 * @author Naoki Sawada
 	 */
-	private function input_filter($args) {
+	protected function input_filter($args) {
 		static $magic_quotes_gpc = NULL;
 		
 		if ($magic_quotes_gpc === NULL)


### PR DESCRIPTION
Given that almost all methods, `elFinderConnector` provides are already protected (or public), thus is meant to be sub-classed and `input_filter()` is useful in derived classes, too, make it protected instead of private.