### PR TITLE
Fix for issue #1146

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -1029,7 +1029,7 @@ window.elFinder = function(node, opts) {
 	 * @return Integer
 	 */
 	this.returnBytes = function(val) {
-		if (val == '-1') val = 0;
+		if (val < '1') val = 0;
 		if (val) {
 			// for ex. 1mb, 1KB
 			val = val.replace(/b$/i, '');
@@ -1180,7 +1180,7 @@ window.elFinder = function(node, opts) {
 				}
 
 				if (cmd == 'open' && !!data.init) {
-					self.uplMaxSize = parseInt(self.returnBytes(response.uplMaxSize));
+					self.uplMaxSize = self.returnBytes(response.uplMaxSize);
 					self.uplMaxFile = !!response.uplMaxFile? parseInt(response.uplMaxFile) : 20;
 				}
 

--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -1180,7 +1180,7 @@ window.elFinder = function(node, opts) {
 				}
 
 				if (cmd == 'open' && !!data.init) {
-					self.uplMaxSize = self.returnBytes(response.uplMaxSize);
+					self.uplMaxSize = parseInt(self.returnBytes(response.uplMaxSize));
 					self.uplMaxFile = !!response.uplMaxFile? parseInt(response.uplMaxFile) : 20;
 				}
 


### PR DESCRIPTION
Fix for issue #1146.
The connector sends to the client the value of upload_max_filesize in the php.ini. If it is set to 0, the uplMaxSize variable is set to "0" (as string, not numeric) and when getting the BYTES_PER_CHUNK, the or between "0" and a number, it returns "0". So 0 minus 8190 is negative and thus it enters an infinite loop.