### PR TITLE
Double @unlink() on temp file fix

### DIFF
--- a/php/elFinderVolumeDropbox.class.php
+++ b/php/elFinderVolumeDropbox.class.php
@@ -1146,9 +1146,6 @@ class elFinderVolumeDropbox extends elFinderVolumeDriver {
 	 **/
 	protected function _fclose($fp, $path='') {
 		@fclose($fp);
-		if ($path) {
-			@unlink($this->getTempFile($path));
-		}
 	}
 
 	/********************  file/dir manipulations *************************/

--- a/php/elFinderVolumeFTP.class.php
+++ b/php/elFinderVolumeFTP.class.php
@@ -871,9 +871,6 @@ class elFinderVolumeFTP extends elFinderVolumeDriver {
 	 **/
 	protected function _fclose($fp, $path='') {
 		@fclose($fp);
-		if ($path) {
-			@unlink($this->getTempFile($path));
-		}
 	}
 	
 	/********************  file/dir manipulations *************************/

--- a/php/elFinderVolumeMySQL.class.php
+++ b/php/elFinderVolumeMySQL.class.php
@@ -616,9 +616,6 @@ class elFinderVolumeMySQL extends elFinderVolumeDriver {
 	 **/
 	protected function _fclose($fp, $path='') {
 		@fclose($fp);
-		if ($path) {
-			@unlink($this->getTempFile($path));
-		}
 	}
 	
 	/********************  file/dir manipulations *************************/

--- a/php/elFinderVolumeS3.class.php
+++ b/php/elFinderVolumeS3.class.php
@@ -412,9 +412,6 @@ class elFinderVolumeS3 extends elFinderVolumeDriver {
 	 **/
 	protected function _fclose($fp, $path='') {
 		@fclose($fp);
-		if ($path) {
-			@unlink($this->getTempFile($path));
-		}
 	}
 	
 	/********************  file/dir manipulations *************************/


### PR DESCRIPTION
All temp files are already unlinked by the shutdown handler which is being registered in getTempFile().
For some reason, I got an error when the second unlink() in the handler tried to delete a file that was already deleted by the first unlink() call (although both unlink calls are prefixed with an '@').