### PR TITLE
Typo fix

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -652,7 +652,7 @@ window.elFinder = function(node, opts) {
 		this.sortStickFolders = !!this.sortStickFolders
 	}
 
-	this.sortRules = $.extend(true, {}, this._sortRules, this.options.sortsRules);
+	this.sortRules = $.extend(true, {}, this._sortRules, this.options.sortRules);
 	
 	$.each(this.sortRules, function(name, method) {
 		if (typeof method != 'function') {


### PR DESCRIPTION
According to https://github.com/Studio-42/elFinder/blob/master/js/elFinder.options.js#L481, the variable needs to be called `sortRules`