### PR TITLE
elFinderSession: Only start session if it isn't already running

### DIFF
--- a/php/elFinderSession.php
+++ b/php/elFinderSession.php
@@ -38,8 +38,12 @@ class elFinderSession implements elFinderSessionInterface
      */
 	public function start()
 	{
-		@session_start();
-		$this->started = session_id()? true : false;
+		if (session_id()) {
+			$this->started = true;
+		} else {
+			@session_start();
+			$this->started = session_id() ? true : false;
+		}
 		
 		return $this;
 	}


### PR DESCRIPTION
The current implementation is problematic for us. We embed elFinder in a framework where a PHP session is already started, and because we use ErrorExceptions, the silence operator (@) doesn't supress the error when the session is started a second time.