### PR TITLE
use npm for installing build dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "elFinder",
+  "version": "2.1.11",
+  "description": "File manager for web",
+  "main": "Jakefile.js",
+  "scripts": {
+    "build": "mkdir -p ./build && jake -C ./build elfinder"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Studio-42/elFinder.git"
+  },
+  "keywords": [
+    "file",
+    "manager",
+    "jquery",
+    "jqueryui",
+    "frontend",
+    "client-side",
+    "browser"
+  ],
+  "author": "Studio 42",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/Studio-42/elFinder/issues"
+  },
+  "homepage": "http://studio-42.github.io/elFinder/",
+  "devDependencies": {
+    "csso": "<2.0.0",
+    "jake": "~8.0.12",
+    "uglify-js": "~2.6.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "elFinder",
-  "version": "2.1.11",
   "description": "File manager for web",
   "main": "Jakefile.js",
   "scripts": {


### PR DESCRIPTION
Now you can simply use `npm install` which will install nodejs packages required to build elfinder, also by running `npm run-script build` will build elfinder into ./build dir.

Once `npm install` is run it will install npm packages into `./node_modules` by default. You can execute jake by running `./node_modules/.bin/jake`.

This is the default way to go with npm.