### PR TITLE
Support the attribute "ts"

### DIFF
--- a/js/proxy/elFinderSupportVer1.js
+++ b/js/proxy/elFinderSupportVer1.js
@@ -328,6 +328,7 @@ window.elFinderSupportVer1 = function(upload) {
 				name   : file.name,
 				mime   : mime,
 				date   : file.date || this.fm.formatDate(file),
+				ts     : file.ts,
 				size   : size,
 				read   : file.read,
 				write  : file.write,


### PR DESCRIPTION
Up to now, the modification time of an object was only transported via the "date" attribute and this was also used for sorting.

The "date" attribute was a string, formatted and localised - i.e. "23.05.2016 18:34". For sorting, this does mostly not work as the sort function compares strings and this leads to a wrong order.

Instead, elfinder pefers the "ts" attribute which can be used for sorting easily (numerical value) and is then formatted client-side with JS to be displayed.

This patch allows for an old API server to send the "ts" attribute and thus fix the sorting issue.