### PR TITLE
Fix for text file corruption after edit if encoding is different from UTF-8

### DIFF
--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -2352,7 +2352,7 @@ abstract class elFinderVolumeDriver {
 		}
 		
 		$this->clearcache();
-		return $this->convEncOut($this->_filePutContents($this->convEncIn($path), $content)) ? $this->stat($path) : false;
+		return $this->convEncOut($this->_filePutContents($this->convEncIn($path), $this->convEncIn($content))) ? $this->stat($path) : false;
 	}
 
 	/**


### PR DESCRIPTION
I have elFinder 2.1 running on Windows server with Cyrillic (CP1251) codepage.

In order to get proper filesysem encoding of files and folders I create via web UI I have to specify 'encoding' as 'CP1251' in connector configuration. This also makes elFinder assume text files are stored in CP1251 too, that is fine for me.

Then, if I edit such a text file via web UI, it is loaded as CP1251-encoded but saved as UTF-8-encoded. elFinder cannot properly display this file the second time I open it: text becomes corrupted because UTF-8 data is interpreted as being CP1251. Saving the file writes down this corrupted content to disk.

This pull request fixes the problem.