### PR TITLE
[WIP] Added a "disabledInside" option

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -108,19 +108,20 @@ var elFinder = function(node, opts) {
 		 * @type Object
 		 **/
 		cwdOptions = {
-			path          : '',
-			url           : '',
-			tmbUrl        : '',
-			disabled      : [],
-			separator     : '/',
-			archives      : [],
-			extract       : [],
-			copyOverwrite : true,
+			path            : '',
+			url             : '',
+			tmbUrl          : '',
+			disabled        : [],
+			disabledInside  : [],
+			separator       : '/',
+			archives        : [],
+			extract         : [],
+			copyOverwrite   : true,
 			uploadOverwrite : true,
-			uploadMaxSize : 0,
-			jpgQuality    : 100,
-			tmbCrop       : false,
-			tmb           : false // old API
+			uploadMaxSize   : 0,
+			jpgQuality      : 100,
+			tmbCrop         : false,
+			tmb             : false // old API
 		},
 		
 		/**
@@ -1634,10 +1635,14 @@ var elFinder = function(node, opts) {
 						self.newAPI = self.api >= 2;
 						self.oldAPI = !self.newAPI;
 					}
-					
-					if (response.options) {
-						cwdOptions = $.extend({}, cwdOptions, response.options);
-					}
+
+                    // If there are no disabled options in response, we should reset those - we don't want this to be lept
+                    if (!response.options) {
+                        response.options = {};
+                    }
+                    if (!response.options.disabledInside) {
+                        response.options.disabledInside = [];
+                    }
 
 					if (response.netDrivers) {
 						self.netDrivers = response.netDrivers;

--- a/js/ui/contextmenu.js
+++ b/js/ui/contextmenu.js
@@ -318,12 +318,16 @@ $.fn.elfindercontextmenu = function(fm) {
 						}
 					});
 				}
-				if (!isCwd) {
+
+				if (isCwd) {
+					 disabled = fm.option('disabledInside', targets[0]);
+				} else {
 					disabled = fm.option('disabled', targets[0]);
-					if (! disabled) {
-						disabled = [];
-					}
 				}
+				if (! disabled) {
+					disabled = [];
+				}
+
 				if (type === 'navbar') {
 					fm.select({selected: targets, origin: 'navbar'});
 				}
@@ -351,7 +355,7 @@ $.fn.elfindercontextmenu = function(fm) {
 					}
 					cmd = fm.getCommand(name);
 
-					if (cmd && !isCwd && (!fm.searchStatus.state || !cmd.disableOnSearch)) {
+					if (cmd && (!fm.searchStatus.state || !cmd.disableOnSearch)) {
 						cmd.__disabled = cmd._disabled;
 						cmd._disabled = !(cmd.alwaysEnabled || (fm._commands[name] ? $.inArray(name, disabled) === -1 : false));
 						$.each(cmd.linkedCmds, function(i, n) {


### PR DESCRIPTION
Hello,

On an item returned by the connector, you can set some commands you want to disable.
This PR adds a similar `disabledInside` option, that allows to disable some commands when this item is your current working dir.

It does not overlap with `disabled` option at all, you can see as an option to disable commands when you click in the free space (like making a new folder...). Also that way BC is preserved.