### PR TITLE
commands/download: fixed up timeouts for bad connection download

### DIFF
--- a/js/commands/download.js
+++ b/js/commands/download.js
@@ -251,7 +251,7 @@ elFinder.prototype.commands.download = function() {
 										dfd.resolve();
 										setTimeout(function() {
 											iframe.remove();
-										}, fm.UA.Firefox? 20000 : 1000); // give mozilla 20 sec file to be saved
+										}, 20000); // give 20 sec file to be saved
 									});
 							}
 						}
@@ -321,7 +321,7 @@ elFinder.prototype.commands.download = function() {
 						$(iframes).each(function() {
 							$('#' + $(this).attr('id')).remove();
 						});
-					}, fm.UA.Firefox? (20000 + (10000 * i)) : 1000); // give mozilla 20 sec + 10 sec for each file to be saved
+					}, 20000 + (10000 * i)); // give 20 sec + 10 sec for each file to be saved
 				});
 			fm.trigger('download', {files : files});
 			return dfrd.resolve();


### PR DESCRIPTION
We got issues from customers about download problem:
some ftps have an authorization lags, which are about one second.

When they are downloading file from slow ftp, they have got cancelled download task (frame was removed).

This fix keeps firefox timeouts. There are no any reason why we should remove frame after one second from file download.