### PR TITLE
Add support for X-Sendfile and similar file-download accelerators

### DIFF
--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -1526,13 +1526,21 @@ class elFinder {
 				'Connection: close'
 			)
 		);
-
-
-		$xsendfile = $volume->options($target)['xsendfile'];
-		$realpath = $volume->realpath($target);
-		if ($xsendfile !== '' && $realpath !== false) {
-			$result['header'][] = $xsendfile . ': ' . $realpath;
-		} else if (isset($file['url']) && $file['url'] && $file['url'] != 1) {
+		
+		// check 'xsendfile'
+		$xsendfile = $volume->getOption('xsendfile');
+		$path = null;
+		if ($xsendfile) {
+			$info = stream_get_meta_data($fp);
+			$path = empty($info["uri"])? null : $info["uri"];
+		}
+		if ($path) {
+			$result['header'][] = $xsendfile . ': ' . $path;
+			$result['info']['xsendfile'] = $xsendfile;
+		}
+		
+		// add "Content-Location" if file has url data
+		if (isset($file['url']) && $file['url'] && $file['url'] != 1) {
 			$result['header'][] = 'Content-Location: '.$file['url'];
 		}
 		return $result;

--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -1526,7 +1526,13 @@ class elFinder {
 				'Connection: close'
 			)
 		);
-		if (isset($file['url']) && $file['url'] && $file['url'] != 1) {
+
+
+		$xsendfile = $volume->options($target)['xsendfile'];
+		$realpath = $volume->realpath($target);
+		if ($xsendfile !== '' && $realpath !== false) {
+			$result['header'][] = $xsendfile . ': ' . $realpath;
+		} else if (isset($file['url']) && $file['url'] && $file['url'] != 1) {
 			$result['header'][] = 'Content-Location: '.$file['url'];
 		}
 		return $result;

--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -407,7 +407,9 @@ abstract class elFinderVolumeDriver {
 		'utf8fix'      => false,
 		 //                           й                 ё              Й               Ё              Ø         Å
 		'utf8patterns' => array("\u0438\u0306", "\u0435\u0308", "\u0418\u0306", "\u0415\u0308", "\u00d8A", "\u030a"),
-		'utf8replace'  => array("\u0439",        "\u0451",       "\u0419",       "\u0401",       "\u00d8", "\u00c5")
+		'utf8replace'  => array("\u0439",        "\u0451",       "\u0419",       "\u0401",       "\u00d8", "\u00c5"),
+		// Header to use to accelerate sending local files to clients (e.g. 'X-Sendfile', 'X-Accel-Redirect')
+		'xsendfile'    => ''
 	);
 
 	/**
@@ -1604,7 +1606,8 @@ abstract class elFinderVolumeDriver {
 			'syncChkAsTs'     => intval($this->options['syncChkAsTs']),
 			'syncMinMs'       => intval($this->options['syncMinMs']),
 			'i18nFolderName'  => intval($this->options['i18nFolderName']),
-			'tmbCrop'         => intval($this->options['tmbCrop'])
+			'tmbCrop'         => intval($this->options['tmbCrop']),
+			'xsendfile'       => $this->options['xsendfile']
 		);
 		if (! empty($this->options['trashHash'])) {
 			$opts['trashHash'] = $this->options['trashHash'];


### PR DESCRIPTION
I'm new to this codebase, so I did my best to create a patch to resolve #475.

All of the file-based acceleration headers require some amount of configuration on the web server to allow serving files from a path on the system, so this is disabled by default. Once the server has been configured, this functionality can be enabled by adding the "xsendfile" option to a root volume with the name of the header to use (e.g., "X-Sendfile"). The header is configurable because there are a number of variants in the wild, and there is no portable way to know what header should be used.

I have tested this with Apache 2.4 w/ mod_xsendfile 0.12.