### PR TITLE
[js:core] add an option `fileFilter` to make filtering on browsing

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -6356,6 +6356,21 @@ elFinder.prototype = {
 	 */
 	normalize : function(data) {
 		var self   = this,
+			fileFilter = (function() {
+				var func, filter;
+				if (filter = self.options.fileFilter) {
+					if (typeof filter === 'function') {
+						func = function(file) {
+							return filter.call(self, file);
+						}
+					} else if (filter instanceof RegExp) {
+						func = function(file) {
+							return filter.test(file.name);
+						}
+					}
+				}
+				return func? func : null;
+			})(),
 			chkCmdMap = function(opts) {
 				// Disable command to replace with other command
 				var disabled;
@@ -6395,21 +6410,6 @@ elFinder.prototype = {
 				if (file && file.hash && file.name && file.mime) {
 					if (file.mime == 'application/x-empty') {
 						file.mime = 'text/plain';
-					}
-
-                    if (file.mime !== 'directory' && self.options.filenameFilter) {
-                        try {
-                            if (!self.options.filenameFilter.test(file.name)) {
-                                return null;
-                            }
-                        } catch (e) {
-                            // invalid filename filter or filter is not a RegExp
-                            return null
-                        }
-                    }
-
-					if (file.options) {
-						self.optionsByHashes[file.hash] = normalizeOptions(file.options);
 					}
 					
 					isRoot = self.isRoot(file);
@@ -6521,7 +6521,20 @@ elFinder.prototype = {
 						if (self.trashes[file.hash]) {
 							file.locked = true;
 						}
+					} else if (fileFilter) {
+						try {
+							if (! fileFilter(file)) {
+								return null;
+							}
+						} catch(e) {
+							self.debug(e);
+						}
 					}
+					
+					if (file.options) {
+						self.optionsByHashes[file.hash] = normalizeOptions(file.options);
+					}
+					
 					delete file.options;
 					
 					return file;

--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -6397,6 +6397,17 @@ elFinder.prototype = {
 						file.mime = 'text/plain';
 					}
 
+                    if (file.mime !== 'directory' && self.options.filenameFilter) {
+                        try {
+                            if (!self.options.filenameFilter.test(file.name)) {
+                                return null;
+                            }
+                        } catch (e) {
+                            // invalid filename filter or filter is not a RegExp
+                            return null
+                        }
+                    }
+
 					if (file.options) {
 						self.optionsByHashes[file.hash] = normalizeOptions(file.options);
 					}


### PR DESCRIPTION
**Documentation To Be Added**
To filter directory results by filename, set the filenameFilter option to a valid regular expression.

If the filter evaluates to false, no filtering will occur (null, undefined, false, etc)
If the filter is not a RegExp, or an invalid RegExp, no files will pass the filter.
Directory Names are not filtered.

**Examples**
```javascript
{
    // pdf files
    filenameFilter = /.*\.pdf$/i
}
// or
{
    // png and jpg files
    filenameFilter = /.*\.(png|jpg)$/i
}
// or
{
    // no hidden files 
    filenameFilter = /[^\.].*/
}
```
