### PR TITLE
Ftp server with Virtual users and the ftp owner configuration option

### DIFF
--- a/php/elFinderVolumeFTP.class.php
+++ b/php/elFinderVolumeFTP.class.php
@@ -406,11 +406,18 @@ class elFinderVolumeFTP extends elFinderVolumeDriver {
 			$stat['owner'] = $info[2];
 			$stat['group'] = $info[3];
 			$stat['perm']  = substr($info[0], 1);
-			$stat['isowner'] = $stat['owner']? ($stat['owner'] == $this->options['user']) : $this->options['owner'];
+                	//
+			// if not exists owner in LS ftp ==>                    isowner = True
+                	// if is defined as option : 'owner' => true            isowner = True
+                	// 
+                	// if exist owner in LS ftp  and 'owner' => False        isowner =   result of    owner(file) == user(logged with ftp)
+                        //
+			$stat['isowner'] = isset($stat['owner']) ?  (  $this->options['owner'] ? True : ($stat['owner'] == $this->options['user'])) :  True ;  
+
 		}
-		$owner = isset($stat['owner'])? $stat['owner'] : '';
-		
-		$perm = $this->parsePermissions($info[0], $owner);
+
+		$owner_computed  = isset($stat['isowner'])? $stat['isowner'] : $this->options['owner'] ;
+ 		$perm = $this->parsePermissions($info[0], $owner_computed );
 		$stat['name']  = $name;
 		$stat['mime']  = substr(strtolower($info[0]), 0, 1) == 'd' ? 'directory' : $this->mimetype($stat['name'], true);
 		$stat['size']  = $stat['mime'] == 'directory' ? 0 : $info[4];
@@ -448,24 +455,32 @@ class elFinderVolumeFTP extends elFinderVolumeDriver {
 	/**
 	 * Parse permissions string. Return array(read => true/false, write => true/false)
 	 *
-	 * @param  string $perm permissions string
-	 * @param string $user
+	 * @param  string $perm permissions string   'rwx' + 'rwx' + 'rwx'
+          *                                             ^       ^       ^
+         *                                             |       |       +->   others 
+         *                                             |       +--------->   group 
+         *                                             +----------------->   owner
+         * The isowner parameter is computed by the caller.
+	 * If the owner parameter in the options is true, the user is the actual owner of all objects even if che user used in the ftp Login
+	 * is different from the file owner id.
+	 * If the owner parameter is false to understand if the user is the file owner we compare the ftp user with the file owner id.
+	 * @param Boolean $isowner. Tell if the current user is the owner of the object.
 	 * @return string
 	 * @author Dmitry (dio) Levashov
+	 * @author Ugo Vierucci
 	 */
-	protected function parsePermissions($perm, $user = '') {
+	protected function parsePermissions($perm, $isowner = True) {
 		$res   = array();
 		$parts = array();
-		$owner = $user? ($user == $this->options['user']) : $this->options['owner'];
 		for ($i = 0, $l = strlen($perm); $i < $l; $i++) {
 			$parts[] = substr($perm, $i, 1);
 		}
 
-		$read = ($owner && $parts[1] == 'r') || $parts[4] == 'r' || $parts[7] == 'r';
+		$read = ($isowner && $parts[1] == 'r') || $parts[4] == 'r' || $parts[7] == 'r';
 		
 		return array(
-			'read'  => $parts[0] == 'd' ? $read && (($owner && $parts[3] == 'x') || $parts[6] == 'x' || $parts[9] == 'x') : $read,
-			'write' => ($owner && $parts[2] == 'w') || $parts[5] == 'w' || $parts[8] == 'w'
+			'read'  => $parts[0] == 'd' ? $read && (($isowner && $parts[3] == 'x') || $parts[6] == 'x' || $parts[9] == 'x') : $read,
+			'write' => ($isowner && $parts[2] == 'w') || $parts[5] == 'w' || $parts[8] == 'w'
 		);
 	}
 	
@@ -878,15 +893,22 @@ class elFinderVolumeFTP extends elFinderVolumeDriver {
 				}
 				
 				$stat['perm'] = trim($stat['perm']);
+				//
+				// if not exists owner in LS ftp ==>                    isowner = True
+				// if is defined as option : 'owner' => true            isowner = True
+        			// 
+        			// if exist owner in LS ftp  and 'owner' => False        isowner =   result of    owner(file) == user(logged with ftp)
 
-				$owner = $this->options['owner'];
-				$read = ($owner && $perm[0][0]) || $perm[1][0] || $perm[2][0];
+				 
+				$owner_computed = isset($stat['owner']) ?  (  $this->options['owner'] ? True : ($stat['owner'] == $this->options['user'])) :  True ;  
 
-				$stat['read']  = $stat['mime'] == 'directory' ? $read && (($owner && $perm[0][2]) || $perm[1][2] || $perm[2][2]) : $read;
-				$stat['write'] = ($owner && $perm[0][1]) || $perm[1][1] || $perm[2][1];
+       	$read = ($owner_computed && $perm[0][0]) || $perm[1][0] || $perm[2][0];
+
+				$stat['read']  = $stat['mime'] == 'directory' ? $read && (($owner_computed && $perm[0][2]) || $perm[1][2] || $perm[2][2]) : $read;
+				$stat['write'] =  ($owner_computed && $perm[0][1]) || $perm[1][1] || $perm[2][1];
 
 				if ($this->options['statOwner']) {
-					$stat['isowner'] = $owner;
+					$stat['isowner'] = $owner_computed;
 				} else {
 					unset($stat['owner'], $stat['group'], $stat['perm']);
 				}

--- a/php/elFinderVolumeFTP.class.php
+++ b/php/elFinderVolumeFTP.class.php
@@ -406,14 +406,13 @@ class elFinderVolumeFTP extends elFinderVolumeDriver {
 			$stat['owner'] = $info[2];
 			$stat['group'] = $info[3];
 			$stat['perm']  = substr($info[0], 1);
-                	//
-			// if not exists owner in LS ftp ==>                    isowner = True
-                	// if is defined as option : 'owner' => true            isowner = True
-                	// 
-                	// if exist owner in LS ftp  and 'owner' => False        isowner =   result of    owner(file) == user(logged with ftp)
-                        //
-			$stat['isowner'] = isset($stat['owner']) ?  (  $this->options['owner'] ? True : ($stat['owner'] == $this->options['user'])) :  True ;  
-
+			//
+			// if not exists owner in LS ftp ==>                    isowner = true
+			// if is defined as option : 'owner' => true            isowner = true
+			// 
+			// if exist owner in LS ftp  and 'owner' => False       isowner =   result of    owner(file) == user(logged with ftp)
+			//
+			$stat['isowner'] = isset($stat['owner']) ? ($this->options['owner'] ? true : ($stat['owner'] == $this->options['user'])) : true;
 		}
 
 		$owner_computed  = isset($stat['isowner'])? $stat['isowner'] : $this->options['owner'] ;
@@ -456,11 +455,11 @@ class elFinderVolumeFTP extends elFinderVolumeDriver {
 	 * Parse permissions string. Return array(read => true/false, write => true/false)
 	 *
 	 * @param  string $perm permissions string   'rwx' + 'rwx' + 'rwx'
-          *                                             ^       ^       ^
-         *                                             |       |       +->   others 
-         *                                             |       +--------->   group 
-         *                                             +----------------->   owner
-         * The isowner parameter is computed by the caller.
+	 *                                             ^       ^       ^
+	 *                                             |       |       +->   others 
+	 *                                             |       +--------->   group 
+	 *                                             +----------------->   owner
+	 * The isowner parameter is computed by the caller.
 	 * If the owner parameter in the options is true, the user is the actual owner of all objects even if che user used in the ftp Login
 	 * is different from the file owner id.
 	 * If the owner parameter is false to understand if the user is the file owner we compare the ftp user with the file owner id.
@@ -469,7 +468,7 @@ class elFinderVolumeFTP extends elFinderVolumeDriver {
 	 * @author Dmitry (dio) Levashov
 	 * @author Ugo Vierucci
 	 */
-	protected function parsePermissions($perm, $isowner = True) {
+	protected function parsePermissions($perm, $isowner = true) {
 		$res   = array();
 		$parts = array();
 		for ($i = 0, $l = strlen($perm); $i < $l; $i++) {
@@ -894,15 +893,14 @@ class elFinderVolumeFTP extends elFinderVolumeDriver {
 				
 				$stat['perm'] = trim($stat['perm']);
 				//
-				// if not exists owner in LS ftp ==>                    isowner = True
-				// if is defined as option : 'owner' => true            isowner = True
-        			// 
-        			// if exist owner in LS ftp  and 'owner' => False        isowner =   result of    owner(file) == user(logged with ftp)
+				// if not exists owner in LS ftp ==>                    isowner = true
+				// if is defined as option : 'owner' => true            isowner = true
+				// 
+				// if exist owner in LS ftp  and 'owner' => False        isowner =   result of    owner(file) == user(logged with ftp)
 
-				 
-				$owner_computed = isset($stat['owner']) ?  (  $this->options['owner'] ? True : ($stat['owner'] == $this->options['user'])) :  True ;  
+				$owner_computed = isset($stat['owner']) ? ($this->options['owner'] ? true : ($stat['owner'] == $this->options['user'])) : true;
 
-       	$read = ($owner_computed && $perm[0][0]) || $perm[1][0] || $perm[2][0];
+				$read = ($owner_computed && $perm[0][0]) || $perm[1][0] || $perm[2][0];
 
 				$stat['read']  = $stat['mime'] == 'directory' ? $read && (($owner_computed && $perm[0][2]) || $perm[1][2] || $perm[2][2]) : $read;
 				$stat['write'] =  ($owner_computed && $perm[0][1]) || $perm[1][1] || $perm[2][1];
@@ -1648,4 +1646,3 @@ class elFinderVolumeFTP extends elFinderVolumeDriver {
 	}
 
 } // END class
-


### PR DESCRIPTION
Here is the Pull Request to resolve this issue
#2194 
Now we consider the option owner in this way:
1. If the option owner is True it means that we don't check if we are the system owner of the object, elFinder will always considerer you the owner. This is the same default behaviour of other ftp clients and it's the only way to use Virtual users.
2. If the option owner is False or Empty Elfinder will compare the file system user with the logged user and so if the user of the file is equal to the ftp user, the logged user will be the owner otherwise it will be an other user.
So if the logged in ftp user is a Virtual User we could set the option owner to True, if the logged in ftp user is also a system user we can set the owner option to False.

We could add this usage for the option owner here https://github.com/Studio-42/elFinder/wiki/Connector-configuration-options-2.1
Actually its default value is True. This means that when we mount a new FTP Driver using the interface with this fix we will have the combination Virtual User with owner = True or System User with owner = true. So in the last case ElFinder will not compare the logged in ftp user with the file owner, nevertheless the user is able to make any action for both cases. If the virtual user cannot change the file the right message is already shown. 

To resolve this we could add a check box to say if the user is a Virtual user in the __Mount Network Volume__ when the ftp is selected.

Below we can see the same cases of the issue but with the fix applied:

### 1. Ftp Driver, Virtual User, option owner = true
![ftpdrivervirtualuserownertrue](https://user-images.githubusercontent.com/24244107/30175616-7a2c136a-93ff-11e7-9ba9-761503bc6071.png)
Now the user can work adding editing and deleting files. The drawback is if a file is of an other user and we try to write we will get an error message, see this two files:
1. F755root.txt
2. F644root.txt

### 2. Ftp Driver, Virtual User, option owner = false
![ftpdrivervirtualuserownerfalse](https://user-images.githubusercontent.com/24244107/30175589-5759ae9c-93ff-11e7-8feb-029ad92c7705.png)
This combination it's not good.

### 3. Ftp Driver, user Owner, option owner = true
![ftpdriverrealuserownertrue](https://user-images.githubusercontent.com/24244107/30175623-8574055c-93ff-11e7-8fd5-f6f699a28354.png)
The user can work adding editing and deleting files. The drawback is if a file is of an other user and we try to write we will get an error message, see this two files:
1. F755root.txt
2. F644root.txt

### 4. Ftp Driver, user Owner, option owner = false
![ftpdriverrealuserownerfalse](https://user-images.githubusercontent.com/24244107/30175637-8d80ce42-93ff-11e7-80e1-83f19f336738.png)
I don't see any problem, the best combination.
