### PR TITLE
[php:core] use `fopen($volume->getTempFile(), 'wb')` instead `tmpfile()`

### DIFF
--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -2882,7 +2882,10 @@ class elFinder {
 		
 		if ($encoding === 'scheme') {
 			if (preg_match('~^https?://~i', $args['content'])) {
-				$fp = $this->get_remote_contents($args['content'], 30, 5, 'Mozilla/5.0', tmpfile());
+				$tempDir = $this->getTempDir($volume->getTempPath());
+				$tmpfname = $tempDir . DIRECTORY_SEPARATOR . 'tmp_' . md5($args['content'].microtime(true));
+				$fpt = fopen($tmpfname, 'wb');
+				$fp = $this->get_remote_contents($args['content'], 30, 5, 'Mozilla/5.0', $fpt);
 				if (! $fp) {
 					return  array('error' => self::ERROR_SAVE, $args['content'], self::ERROR_FILE_NOT_FOUND);
 				}

--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -2882,7 +2882,7 @@ class elFinder {
 		
 		if ($encoding === 'scheme') {
 			if (preg_match('~^https?://~i', $args['content'])) {
-				$fp = $this->get_remote_contents($args['content'], 30, 5, 'Mozilla/5.0', fopen($volume->getTempFile, 'wb'));
+				$fp = $this->get_remote_contents($args['content'], 30, 5, 'Mozilla/5.0', fopen($volume->getTempFile(), 'wb'));
 				if (! $fp) {
 					return  array('error' => self::ERROR_SAVE, $args['content'], self::ERROR_FILE_NOT_FOUND);
 				}

--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -2882,10 +2882,7 @@ class elFinder {
 		
 		if ($encoding === 'scheme') {
 			if (preg_match('~^https?://~i', $args['content'])) {
-				$tempDir = $this->getTempDir($volume->getTempPath());
-				$tmpfname = $tempDir . DIRECTORY_SEPARATOR . 'tmp_' . md5($args['content'].microtime(true));
-				$fpt = fopen($tmpfname, 'wb');
-				$fp = $this->get_remote_contents($args['content'], 30, 5, 'Mozilla/5.0', $fpt);
+				$fp = $this->get_remote_contents($args['content'], 30, 5, 'Mozilla/5.0', fopen($this->getTempFile, 'wb'));
 				if (! $fp) {
 					return  array('error' => self::ERROR_SAVE, $args['content'], self::ERROR_FILE_NOT_FOUND);
 				}

--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -2882,7 +2882,7 @@ class elFinder {
 		
 		if ($encoding === 'scheme') {
 			if (preg_match('~^https?://~i', $args['content'])) {
-				$fp = $this->get_remote_contents($args['content'], 30, 5, 'Mozilla/5.0', fopen($this->getTempFile, 'wb'));
+				$fp = $this->get_remote_contents($args['content'], 30, 5, 'Mozilla/5.0', fopen($volume->getTempFile, 'wb'));
 				if (! $fp) {
 					return  array('error' => self::ERROR_SAVE, $args['content'], self::ERROR_FILE_NOT_FOUND);
 				}


### PR DESCRIPTION
use getTempDir instead of system tmp path, to prevent an error when tmp is not in open_basedir list
WARNING: finfo_file(): open_basedir restriction in effect. File(/tmp/phpoIyUCq) is not within the allowed path(s): (/var/www/website/data:.) in elFinder.class.php line 2123.
#2205