### PR TITLE
[VD:abstract] use `fopen($this->getTempFile(),'wb')` instead `tmpfile()`

### DIFF
--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -2654,9 +2654,7 @@ abstract class elFinderVolumeDriver {
 		$mime = '';
 		$mimeByName = $this->mimetype($name, true);
 		if ($this->mimeDetect !== 'internal') {
-			$tempDir = $this->getTempPath();
-			$tmpfname = $tempDir . DIRECTORY_SEPARATOR . 'tmp_' . md5($name.microtime(true));
-			if ($tp = fopen($tmpfname, 'wb')) {
+			if ($tp = fopen($this->getTempFile(), 'wb')) {
 				fwrite($tp, $content);
 				$info = stream_get_meta_data($tp);
 				$filepath = $info['uri'];

--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -2654,7 +2654,9 @@ abstract class elFinderVolumeDriver {
 		$mime = '';
 		$mimeByName = $this->mimetype($name, true);
 		if ($this->mimeDetect !== 'internal') {
-			if ($tp = tmpfile()) {
+			$tempDir = $this->getTempPath();
+			$tmpfname = $tempDir . DIRECTORY_SEPARATOR . 'tmp_' . md5($name.microtime(true));
+			if ($tp = fopen($tmpfname, 'wb')) {
 				fwrite($tp, $content);
 				$info = stream_get_meta_data($tp);
 				$filepath = $info['uri'];


### PR DESCRIPTION
use getTempPath instead of system tmp path, to prevent an error when tmp is not in open_basedir list
WARNING: is_readable(): open_basedir restriction in effect. File(/tmp/phpQNdVDX) is not within the allowed path(s): (/var/www/website/data:.) in elFinderVolumeDriver.class.php line 4195.
#2205