### PR TITLE
Fix Using epsv4 off with Pure-ftpd servers creates a timeout

### DIFF
--- a/php/elFinderVolumeFTP.class.php
+++ b/php/elFinderVolumeFTP.class.php
@@ -258,14 +258,14 @@ class elFinderVolumeFTP extends elFinderVolumeDriver {
 			ftp_raw($this->connect, 'OPTS UTF8 ON' );
 		}
 		
-                $help = ftp_raw($this->connect, 'HELP');
+		$help = ftp_raw($this->connect, 'HELP');
 		$this->isPureFtpd = stripos(implode(' ', $help), 'Pure-FTPd') !== false;
-                
-                if(! $this->isPureFtpd){
-                    // switch off extended passive mode - may be usefull for some servers
-                    // this command, for pure-ftpd, doesn't work and takes a timeout in some pure-ftpd versions
-                    ftp_raw($this->connect, 'epsv4 off' );
-                }
+		
+		if(! $this->isPureFtpd){
+			// switch off extended passive mode - may be usefull for some servers
+			// this command, for pure-ftpd, doesn't work and takes a timeout in some pure-ftpd versions
+			ftp_raw($this->connect, 'epsv4 off' );
+		}
 		// enter passive mode if required
 		$pasv = ($this->options['mode'] == 'passive');
 		if (! ftp_pasv($this->connect, $pasv)) {

--- a/php/elFinderVolumeFTP.class.php
+++ b/php/elFinderVolumeFTP.class.php
@@ -258,8 +258,14 @@ class elFinderVolumeFTP extends elFinderVolumeDriver {
 			ftp_raw($this->connect, 'OPTS UTF8 ON' );
 		}
 		
-		// switch off extended passive mode - may be usefull for some servers
-		ftp_raw($this->connect, 'epsv4 off' );
+                $help = ftp_raw($this->connect, 'HELP');
+		$this->isPureFtpd = stripos(implode(' ', $help), 'Pure-FTPd') !== false;
+                
+                if(! $this->isPureFtpd){
+                    // switch off extended passive mode - may be usefull for some servers
+                    // this command, for pure-ftpd, doesn't work and takes a timeout in some pure-ftpd versions
+                    ftp_raw($this->connect, 'epsv4 off' );
+                }
 		// enter passive mode if required
 		$pasv = ($this->options['mode'] == 'passive');
 		if (! ftp_pasv($this->connect, $pasv)) {
@@ -288,9 +294,6 @@ class elFinderVolumeFTP extends elFinderVolumeDriver {
 				break;
 			}
 		}
-		
-		$help = ftp_raw($this->connect, 'HELP');
-		$this->isPureFtpd = stripos(implode(' ', $help), 'Pure-FTPd') !== false;
 		
 		return true;
 	}


### PR DESCRIPTION
Here is the fix to remove the client timeout when the ftp server is pure-ftpd, like is explained in the issue #2212.

Maybe we could think to remove this line:
```php
ftp_raw($this->connect, 'epsv4 off' );
```
but I don't know why it was introduced and what kind of ftp servers could understand the command.
The problem, however, is only for the current versions of pure-ftpd, others servers should answer:
```cmd
500 Unknown Command
```
Luca