### PR TITLE
False errors using the LocalFileSystem Driver and working with empty

### DIFF
--- a/php/elFinderVolumeLocalFileSystem.class.php
+++ b/php/elFinderVolumeLocalFileSystem.class.php
@@ -934,7 +934,10 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 	 * @author Dmitry (dio) Levashov
 	 **/
 	protected function _filePutContents($path, $content) {
-		return file_put_contents($path, $content, LOCK_EX);
+            if (file_put_contents($path, $content, LOCK_EX) === false) {
+                return false;
+            }
+            return true;
 	}
 
 	/**

--- a/php/elFinderVolumeLocalFileSystem.class.php
+++ b/php/elFinderVolumeLocalFileSystem.class.php
@@ -934,10 +934,7 @@ class elFinderVolumeLocalFileSystem extends elFinderVolumeDriver {
 	 * @author Dmitry (dio) Levashov
 	 **/
 	protected function _filePutContents($path, $content) {
-            if (file_put_contents($path, $content, LOCK_EX) === false) {
-                return false;
-            }
-            return true;
+		return (file_put_contents($path, $content, LOCK_EX) !== false);
 	}
 
 	/**


### PR DESCRIPTION
Fix for this bug #2226
The problem is that the php function file_put_contents returns the number of bytes that were written to the file, or FALSE on failure. 
```php
protected function _filePutContents($path, $content) {
		return file_put_contents($path, $content, LOCK_EX);
	}
```
So the response on  Failure was False and the response for an empty file correctly saved was 0.
I changed the function to return only Boolean value.