### PR TITLE
Update elFinderVolumeDriver.class.php

### DIFF
--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -2316,7 +2316,7 @@ abstract class elFinderVolumeDriver {
 		}
 
 		if (!$this->allowPutMime($mime) || ($mimeByName && !$this->allowPutMime($mimeByName))) {
-			return $this->setError(elFinder::ERROR_UPLOAD_FILE_MIME);
+			return $this->setError(elFinder::ERROR_UPLOAD_FILE_MIME, $mime);
 		}
 
 		$tmpsize = sprintf('%u', filesize($tmpname));

--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -2316,7 +2316,7 @@ abstract class elFinderVolumeDriver {
 		}
 
 		if (!$this->allowPutMime($mime) || ($mimeByName && !$this->allowPutMime($mimeByName))) {
-			return $this->setError(elFinder::ERROR_UPLOAD_FILE_MIME, $mime);
+			return $this->setError(elFinder::ERROR_UPLOAD_FILE_MIME, '(' . $mime . ')');
 		}
 
 		$tmpsize = sprintf('%u', filesize($tmpname));


### PR DESCRIPTION
Make mime error message more informative. Show mime type blocked.
Cause I faced a problem uploading tgz files and spent several hours finding right mime type, which I need to allow.

function elFinder->upload() required application/x-compressed type
and
function elFinderVolumeDriver->upload() required additional type application/x-gzip

But a VolumeDriver showed only an error: File type not allowed.

Now it will show:
File type not allowed.
(application/x-gzip)