### PR TITLE
Make help links in one line

### DIFF
--- a/css/commands.css
+++ b/css/commands.css
@@ -345,7 +345,12 @@ div.elfinder-cwd-wrapper-list tr.ui-state-default td span.ui-icon {
 
 .elfinder-help-separator { clear:both; padding:.5em;  }
 
-.elfinder-help-link { padding:2px; }
+.elfinder-help-link {
+	display:inline-block;
+	margin-right:7px;
+	padding:2px;
+	white-space:nowrap;
+}
 
 .elfinder-help .ui-priority-secondary { font-size:.9em;}
 

--- a/css/commands.css
+++ b/css/commands.css
@@ -351,6 +351,10 @@ div.elfinder-cwd-wrapper-list tr.ui-state-default td span.ui-icon {
 	padding:2px 0;
 	white-space:nowrap;
 }
+.elfinder-rtl .elfinder-help-link {
+	margin-right:0;
+	margin-left:12px;
+}
 
 .elfinder-help .ui-priority-secondary { font-size:.9em;}
 

--- a/css/commands.css
+++ b/css/commands.css
@@ -347,8 +347,8 @@ div.elfinder-cwd-wrapper-list tr.ui-state-default td span.ui-icon {
 
 .elfinder-help-link {
 	display:inline-block;
-	margin-right:7px;
-	padding:2px;
+	margin-right:12px;
+	padding:2px 0;
 	white-space:nowrap;
 }
 


### PR DESCRIPTION
Propose to set help links in one line.

Before:

![sclrolh](https://user-images.githubusercontent.com/4941848/32404958-9b9d5bc2-c16c-11e7-9041-6f166e3c46ea.png)

After:

![uyztjjo](https://user-images.githubusercontent.com/4941848/32404961-a0612f8a-c16c-11e7-9fe5-622d71e38ab6.png)

Compact view:

![c2ywptl](https://user-images.githubusercontent.com/4941848/32404963-a3a98c78-c16c-11e7-8086-d1272f42779d.png)

RTL:

![esjhr1n](https://user-images.githubusercontent.com/4941848/32404964-a7dae544-c16c-11e7-8c24-61c448cc558e.png)
