### PR TITLE
Add support for FTP+SSL

### DIFF
--- a/php/elFinderVolumeFTP.class.php
+++ b/php/elFinderVolumeFTP.class.php
@@ -244,10 +244,9 @@ class elFinderVolumeFTP extends elFinderVolumeDriver {
 	 * @author Dmitry (dio) Levashov
 	 **/
 	protected function connect() {
-		if ($this->options['ssl']==true && !($this->connect = ftp_ssl_connect($this->options['host'], $this->options['port'], $this->options['timeout']))) {
+		if (!empty($this->options['ssl']) && !($this->connect = ftp_ssl_connect($this->options['host'], $this->options['port'], $this->options['timeout']))) {
 			return $this->setError('Unable to connect to FTP server '.$this->options['host'].' with SSL');
-		}
-		elseif (!($this->connect = ftp_connect($this->options['host'], $this->options['port'], $this->options['timeout']))) {
+		} else if (!($this->connect = ftp_connect($this->options['host'], $this->options['port'], $this->options['timeout']))) {
 			return $this->setError('Unable to connect to FTP server '.$this->options['host']);
 		}
 		if (!ftp_login($this->connect, $this->options['user'], $this->options['pass'])) {

--- a/php/elFinderVolumeFTP.class.php
+++ b/php/elFinderVolumeFTP.class.php
@@ -98,6 +98,7 @@ class elFinderVolumeFTP extends elFinderVolumeDriver {
 			'pass'          => '',
 			'port'          => 21,
 			'mode'        	=> 'passive',
+			'ssl'        	=> false,
 			'path'			=> '/',
 			'timeout'		=> 20,
 			'owner'         => true,
@@ -243,7 +244,10 @@ class elFinderVolumeFTP extends elFinderVolumeDriver {
 	 * @author Dmitry (dio) Levashov
 	 **/
 	protected function connect() {
-		if (!($this->connect = ftp_connect($this->options['host'], $this->options['port'], $this->options['timeout']))) {
+		if ($this->options['ssl']==true && !($this->connect = ftp_ssl_connect($this->options['host'], $this->options['port'], $this->options['timeout']))) {
+			return $this->setError('Unable to connect to FTP server '.$this->options['host'].' with SSL');
+		}
+		elseif (!($this->connect = ftp_connect($this->options['host'], $this->options['port'], $this->options['timeout']))) {
 			return $this->setError('Unable to connect to FTP server '.$this->options['host']);
 		}
 		if (!ftp_login($this->connect, $this->options['user'], $this->options['pass'])) {


### PR DESCRIPTION
In case of SSL use php function: ftp_ssl_connect(...)
Setting the driver options with SSL:
```
array(
    'driver'        => 'FTP',
    'host'          => 'localhost',
    'user'          => 'eluser',
    'pass'          => 'elpass',
    'port'          => 21,
    'ssl'           => true, // true or false, default: false
    'mode'          => 'passive',
    'path'          => '/',
    'timeout'       => 10,
    'owner'         => true,
    'tmbPath'       => '',
    'tmpPath'       => '',
    'dirMode'       => 0755,
    'fileMode'      => 0644
)
```