### PR TITLE
rename update event to previewupdate because of conflict with prototype

### DIFF
--- a/css/quicklook.css
+++ b/css/quicklook.css
@@ -122,7 +122,8 @@
 }
 .elfinder-quicklook-titlebar-icon .ui-icon {
 	position: relative;
-	margin: -9px 3px 0px 0px;
+	margin: 0px 3px 0px 0px;
+	display: inline-block;
 	cursor: pointer;
 	border-radius: 10px;
 	border: 1px solid;

--- a/js/commands/quicklook.js
+++ b/js/commands/quicklook.js
@@ -382,7 +382,7 @@
 			info.html('');
 		})
 		// update info/icon
-		.on('update', function(e) {
+		.on('previewupdate', function(e) {
 			var fm      = self.fm,
 				preview = self.preview,
 				file    = e.file,
@@ -741,12 +741,12 @@
 							// try re-get file object
 							self.value = Object.assign({}, fm.file(self.value.hash));
 						}
-						preview.trigger($.Event('update', {file : self.value}));
+						preview.trigger($.Event('previewupdate', {file : self.value}));
 					}
 				}
 			});
 			
-			preview.on('update', function(e) {
+			preview.on('previewupdate', function(e) {
 				var file, hash, serach;
 				
 				if (file = e.file) {
@@ -816,7 +816,7 @@
 				$.each(e.data.changed, function() {
 					if (self.window.data('hash') === this.hash) {
 						self.window.data('hash', null);
-						self.preview.trigger('update');
+						self.preview.trigger('previewupdate');
 						return false;
 					}
 				});

--- a/js/commands/quicklook.plugins.js
+++ b/js/commands/quicklook.plugins.js
@@ -29,7 +29,7 @@ elFinder.prototype.commands.quicklook.plugins = [
 			} 
 		});
 			
-		preview.on('update', function(e) {
+		preview.on('previewupdate', function(e) {
 			var fm   = ql.fm,
 				file = e.file,
 				showed = false,
@@ -178,7 +178,7 @@ elFinder.prototype.commands.quicklook.plugins = [
 			},
 			PSD;
 		
-		preview.on('update', function(e) {
+		preview.on('previewupdate', function(e) {
 			var file = e.file,
 				url, img, loading, m,
 				_define, _require;
@@ -226,7 +226,7 @@ elFinder.prototype.commands.quicklook.plugins = [
 			preview = ql.preview,
 			fm      = ql.fm;
 			
-		preview.on('update', function(e) {
+		preview.on('previewupdate', function(e) {
 			var file = e.file, jqxhr, loading;
 			
 			if (ql.dispInlineRegex.test(file.mime) && $.inArray(file.mime, mimes) !== -1) {
@@ -295,7 +295,7 @@ elFinder.prototype.commands.quicklook.plugins = [
 				}
 			};
 		
-		preview.on('update', function(e) {
+		preview.on('previewupdate', function(e) {
 			var file = e.file,
 				mime = file.mime,
 				jqxhr, loading;
@@ -386,7 +386,7 @@ elFinder.prototype.commands.quicklook.plugins = [
 			});
 		}
 
-		active && preview.on('update', function(e) {
+		active && preview.on('previewupdate', function(e) {
 			var file = e.file, node;
 			
 			if (ql.dispInlineRegex.test(file.mime) && file.mime == mime) {
@@ -421,7 +421,7 @@ elFinder.prototype.commands.quicklook.plugins = [
 			});
 		});
 		
-		active && preview.on('update', function(e) {
+		active && preview.on('previewupdate', function(e) {
 			var file = e.file,
 				node;
 				
@@ -462,7 +462,7 @@ elFinder.prototype.commands.quicklook.plugins = [
 			win  = ql.window,
 			navi = ql.navbar;
 
-		preview.on('update', function(e) {
+		preview.on('previewupdate', function(e) {
 			var file = e.file,
 				type = mimes[file.mime],
 				autoplay = ql.autoPlay(),
@@ -524,7 +524,7 @@ elFinder.prototype.commands.quicklook.plugins = [
 			navi = ql.navbar,
 			cHls, cDash;
 
-		preview.on('update', function(e) {
+		preview.on('previewupdate', function(e) {
 			var file = e.file,
 				autoplay = ql.autoPlay(),
 				type = mimes[file.mime.toLowerCase()],
@@ -648,7 +648,7 @@ elFinder.prototype.commands.quicklook.plugins = [
 			});
 		});
 		
-		preview.on('update', function(e) {
+		preview.on('previewupdate', function(e) {
 			var file  = e.file,
 				mime  = file.mime,
 				video,
@@ -730,7 +730,7 @@ elFinder.prototype.commands.quicklook.plugins = [
 			Zlib;
 
 		if (window.Uint8Array && window.DataView && fm.options.cdns.zlibUnzip && fm.options.cdns.zlibGunzip) {
-			preview.on('update', function(e) {
+			preview.on('previewupdate', function(e) {
 				var file = e.file,
 					doc, xhr, loading, url,
 					req = function() {
@@ -846,7 +846,7 @@ elFinder.prototype.commands.quicklook.plugins = [
 			RAR;
 
 		if (window.DataView) {
-			preview.on('update', function(e) {
+			preview.on('previewupdate', function(e) {
 				var file = e.file,
 					loading, url, archive, abort,
 					getList = function(url) {
@@ -968,7 +968,7 @@ elFinder.prototype.commands.quicklook.plugins = [
 			navi    = ql.navbar,
 			node;
 			
-		preview.on('update', function(e) {
+		preview.on('previewupdate', function(e) {
 			var win     = ql.window,
 				file    = e.file,
 				setNavi = function() {
@@ -995,7 +995,7 @@ elFinder.prototype.commands.quicklook.plugins = [
 							file.url = rfile.url = data.url || '';
 							if (file.url) {
 								preview.trigger({
-									type: 'update',
+									type: 'previewupdate',
 									file: file,
 									forceUpdate: true
 								});

--- a/js/commands/quicklook.plugins.js
+++ b/js/commands/quicklook.plugins.js
@@ -374,16 +374,18 @@ elFinder.prototype.commands.quicklook.plugins = [
 			preview = ql.preview,
 			active  = false;
 			
-		if ((fm.UA.Safari && fm.OS === 'mac' && !fm.UA.iOS) || fm.UA.IE) {
-			active = true;
-		} else {
-			$.each(navigator.plugins, function(i, plugins) {
-				$.each(plugins, function(i, plugin) {
-					if (plugin.type == mime) {
-						return !(active = true);
-					}
+		if (!fm.options.ViewerJS) {
+			if ((fm.UA.Safari && fm.OS === 'mac' && !fm.UA.iOS) || fm.UA.IE) {
+				active = true;
+			} else {
+				$.each(navigator.plugins, function(i, plugins) {
+					$.each(plugins, function(i, plugin) {
+						if (plugin.type == mime) {
+							return !(active = true);
+						}
+					});
 				});
-			});
+			}
 		}
 
 		active && preview.on('previewupdate', function(e) {
@@ -401,6 +403,36 @@ elFinder.prototype.commands.quicklook.plugins = [
 			
 	},
 	
+        function(ql) {
+                var mimes   = ['application/pdf', 'application/vnd.oasis.opendocument.text'],
+                        preview = ql.preview,
+                        extensions = ['odt','fodt','ott','odp','fodp','otp','ods','fods','ots','pdf'],
+                        fm      = ql.fm;
+
+                fm.options.ViewerJS && preview.on('previewupdate', function(e) {
+                        var file = e.file,
+                                node, extension = file.name.split('.').pop();
+                        extension = extension.toLowerCase();
+                        var pw = parseInt(preview.width()), ph = parseInt(preview.height());
+                        if (pw > 250 && ph > 250 && ($.inArray(file.mime, mimes) !== -1 || $.inArray(extension, extensions) !== -1)) {
+                                e.stopImmediatePropagation();
+                                preview.one('change', function() {
+                                        node.unbind('load').remove();
+                                });
+
+                                node = $('<iframe class="elfinder-quicklook-preview-pdf"/>')
+                                        .hide()
+                                        .appendTo(preview)
+                                        .load(function() {
+                                                ql.hideinfo();
+                                                node.show();
+                                        })
+                                        .attr('src', fm.options.ViewerJS+ql.fm.url(file.hash)+'&viewerjs_filename=/'+file.name);
+                        }
+
+                })
+	},
+
 	/**
 	 * Flash preview plugin
 	 *


### PR DESCRIPTION
I still need prototype js for my app and could not use elfinder because of a conflict with the name of the update event. So I renamed the event to previewupdate. Please integrate the change into mainstream version.
Also I added an option to use ViewerJS as preview for pdf files in quicklook and fixed the quicklook close / dock button alignment