### PR TITLE
Add option onDropWith for plugin function iaEnabled

### DIFF
--- a/php/elFinderPlugin.php
+++ b/php/elFinderPlugin.php
@@ -45,25 +45,25 @@ class elFinderPlugin {
 		}
 		
 		if (isset($opts['onDropWith']) && !is_null($opts['onDropWith'])) {
-            // plugin disabled by default, enabled only if given key is pressed
-            if (isset($_REQUEST['dropWith']) && $_REQUEST['dropWith']) {
-                $onDropWith = $opts['onDropWith'];
-                $action = (int)$_REQUEST['dropWith'];
-                if (!is_array($onDropWith)) {
-                    $onDropWith = array($onDropWith);
-                }
-                foreach($onDropWith as $key) {
-                    $key = (int)$key;
-                    if (($action & $key) === $key) {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
+			// plugin disabled by default, enabled only if given key is pressed
+			if (isset($_REQUEST['dropWith']) && $_REQUEST['dropWith']) {
+				$onDropWith = $opts['onDropWith'];
+				$action = (int)$_REQUEST['dropWith'];
+				if (!is_array($onDropWith)) {
+					$onDropWith = array($onDropWith);
+				}
+				foreach($onDropWith as $key) {
+					$key = (int)$key;
+					if (($action & $key) === $key) {
+						return true;
+					}
+				}
+			}
+			return false;
+		}
 		
 		if (isset($opts['offDropWith']) && ! is_null($opts['offDropWith']) && isset($_REQUEST['dropWith'])) {
-            // plugin enabled by default, disabled only if given key is pressed
+			// plugin enabled by default, disabled only if given key is pressed
 			$offDropWith = $opts['offDropWith'];
 			$action = (int)$_REQUEST['dropWith'];
 			if (! is_array($offDropWith)) {

--- a/php/elFinderPlugin.php
+++ b/php/elFinderPlugin.php
@@ -44,7 +44,26 @@ class elFinderPlugin {
 			return false;
 		}
 		
+		if (isset($opts['onDropWith']) && !is_null($opts['onDropWith'])) {
+            // plugin disabled by default, enabled only if given key is pressed
+            if (isset($_REQUEST['dropWith']) && $_REQUEST['dropWith']) {
+                $onDropWith = $opts['onDropWith'];
+                $action = (int)$_REQUEST['dropWith'];
+                if (!is_array($onDropWith)) {
+                    $onDropWith = array($onDropWith);
+                }
+                foreach($onDropWith as $key) {
+                    $key = (int)$key;
+                    if (($action & $key) === $key) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+		
 		if (isset($opts['offDropWith']) && ! is_null($opts['offDropWith']) && isset($_REQUEST['dropWith'])) {
+            // plugin enabled by default, disabled only if given key is pressed
 			$offDropWith = $opts['offDropWith'];
 			$action = (int)$_REQUEST['dropWith'];
 			if (! is_array($offDropWith)) {

--- a/php/plugins/AutoResize/plugin.php
+++ b/php/plugins/AutoResize/plugin.php
@@ -21,7 +21,10 @@
  *				'preserveExif'   => false,      // Preserve EXIF data (Imagick only)
  *				'forceEffect'    => false,      // For change quality or make progressive JPEG of small images
  *				'targetType'     => IMG_GIF|IMG_JPG|IMG_PNG|IMG_WBMP, // Target image formats ( bit-field )
- *				'offDropWith'    => null        // To disable it if it is dropped with pressing the meta key
+ *				'offDropWith'    => null,       // Enabled by default. To disable it if it is dropped with pressing the meta key
+ *				                                // Alt: 8, Ctrl: 4, Meta: 2, Shift: 1 - sum of each value
+ *				                                // In case of using any key, specify it as an array
+ *				'onDropWith'     => null        // Disabled by default. To enable it if it is dropped with pressing the meta key
  *				                                // Alt: 8, Ctrl: 4, Meta: 2, Shift: 1 - sum of each value
  *				                                // In case of using any key, specify it as an array
  *			)
@@ -41,7 +44,10 @@
  *						'preserveExif'   => false,      // Preserve EXIF data (Imagick only)
  *						'forceEffect'    => false,      // For change quality or make progressive JPEG of small images
  *						'targetType'     => IMG_GIF|IMG_JPG|IMG_PNG|IMG_WBMP, // Target image formats ( bit-field )
- *						'offDropWith'    => null        // To disable it if it is dropped with pressing the meta key
+ *        				'offDropWith'    => null,       // Enabled by default. To disable it if it is dropped with pressing the meta key
+ *        				                                // Alt: 8, Ctrl: 4, Meta: 2, Shift: 1 - sum of each value
+ *        				                                // In case of using any key, specify it as an array
+ *        				'onDropWith'     => null        // Disabled by default. To enable it if it is dropped with pressing the meta key
  *						                                // Alt: 8, Ctrl: 4, Meta: 2, Shift: 1 - sum of each value
  *						                                // In case of using any key, specify it as an array
  *					)

--- a/php/plugins/AutoRotate/plugin.php
+++ b/php/plugins/AutoRotate/plugin.php
@@ -16,7 +16,10 @@
  *			'AutoRotate' => array(
  *				'enable'         => true,       // For control by volume driver
  *				'quality'        => 95,         // JPEG image save quality
- *				'offDropWith'    => null        // To disable it if it is dropped with pressing the meta key
+ *				'offDropWith'    => null,       // Enabled by default. To disable it if it is dropped with pressing the meta key
+ *				                                // Alt: 8, Ctrl: 4, Meta: 2, Shift: 1 - sum of each value
+ *				                                // In case of using any key, specify it as an array
+ *				'onDropWith'     => null        // Disabled by default. To enable it if it is dropped with pressing the meta key
  *				                                // Alt: 8, Ctrl: 4, Meta: 2, Shift: 1 - sum of each value
  *				                                // In case of using any key, specify it as an array
  *			)
@@ -31,7 +34,10 @@
  *					'AutoRotate' => array(
  *						'enable'         => true,       // For control by volume driver
  *						'quality'        => 95,         // JPEG image save quality
- *						'offDropWith'    => null        // To disable it if it is dropped with pressing the meta key
+ *        				'offDropWith'    => null,       // Enabled by default. To disable it if it is dropped with pressing the meta key
+ *        				                                // Alt: 8, Ctrl: 4, Meta: 2, Shift: 1 - sum of each value
+ *        				                                // In case of using any key, specify it as an array
+ *        				'onDropWith'     => null        // Disabled by default. To enable it if it is dropped with pressing the meta key
  *						                                // Alt: 8, Ctrl: 4, Meta: 2, Shift: 1 - sum of each value
  *						                                // In case of using any key, specify it as an array
  *					)

--- a/php/plugins/Watermark/plugin.php
+++ b/php/plugins/Watermark/plugin.php
@@ -23,7 +23,10 @@
  *				'targetType'     => IMG_GIF|IMG_JPG|IMG_PNG|IMG_WBMP, // Target image formats ( bit-field )
  *				'targetMinPixel' => 200,        // Target image minimum pixel size
  *				'interlace'      => IMG_GIF|IMG_JPG, // Set interlacebit image formats ( bit-field )
- *				'offDropWith'    => null        // To disable it if it is dropped with pressing the meta key
+ *				'offDropWith'    => null,       // Enabled by default. To disable it if it is dropped with pressing the meta key
+ *				                                // Alt: 8, Ctrl: 4, Meta: 2, Shift: 1 - sum of each value
+ *				                                // In case of using any key, specify it as an array
+ *				'onDropWith'     => null        // Disabled by default. To enable it if it is dropped with pressing the meta key
  *				                                // Alt: 8, Ctrl: 4, Meta: 2, Shift: 1 - sum of each value
  *				                                // In case of using any key, specify it as an array
  *			)
@@ -45,7 +48,10 @@
  *						'targetType'     => IMG_GIF|IMG_JPG|IMG_PNG|IMG_WBMP, // Target image formats ( bit-field )
  *						'targetMinPixel' => 200,        // Target image minimum pixel size
  *						'interlace'      => IMG_GIF|IMG_JPG, // Set interlacebit image formats ( bit-field )
- *						'offDropWith'    => null        // To disable it if it is dropped with pressing the meta key
+ *        				'offDropWith'    => null,       // Enabled by default. To disable it if it is dropped with pressing the meta key
+ *        				                                // Alt: 8, Ctrl: 4, Meta: 2, Shift: 1 - sum of each value
+ *        				                                // In case of using any key, specify it as an array
+ *        				'onDropWith'     => null        // Disabled by default. To enable it if it is dropped with pressing the meta key
  *						                                // Alt: 8, Ctrl: 4, Meta: 2, Shift: 1 - sum of each value
  *						                                // In case of using any key, specify it as an array
  *					)


### PR DESCRIPTION
It is handy in some cases plugins (AutoResize, AutoRotate, Watermark) to be enabled, but to function only if  given meta key is pressed while dropping images. This is opposite to option offDropWith.

This PR adds such a possibility.

Current functionality (offDropWith) is same and new features are backward compatible.