### PR TITLE
Fix stream reading order to stderr then stdout so it doesn't hang 

### DIFF
--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -5705,8 +5705,8 @@ abstract class elFinderVolumeDriver {
 			$tmpout = '';
 			$tmperr = '';
 
-			$output = stream_get_contents($pipes[1]);
-			$error_output = stream_get_contents($pipes[2]);
+            $error_output = stream_get_contents($pipes[2]);
+            $output = stream_get_contents($pipes[1]);
 
 			fclose($pipes[1]);
 			fclose($pipes[2]);

--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -5705,8 +5705,8 @@ abstract class elFinderVolumeDriver {
 			$tmpout = '';
 			$tmperr = '';
 
-            $error_output = stream_get_contents($pipes[2]);
-            $output = stream_get_contents($pipes[1]);
+			$error_output = stream_get_contents($pipes[2]);
+			$output = stream_get_contents($pipes[1]);
 
 			fclose($pipes[1]);
 			fclose($pipes[2]);


### PR DESCRIPTION
I had a case where elfinder would hang in Open Folder indefinitely or until timeout. This was caused by the reading order for streams.

Currently elfinder is reading stdout before stderr
There is a case where stdout will never return after an error while elfinder is still waiting for it.

I found the solution on stackoverflow for my case 
https://stackoverflow.com/questions/31194152/proc-open-hangs-when-trying-to-read-from-a-stream

