### PR TITLE
Bind listener after upload save

### DIFF
--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -3013,6 +3013,13 @@ class elFinder {
 				'bind' => 'upload'
 			);
 		}
+		
+		// do hook function 'upload.postsave'
+		if (! empty($this->listeners['upload.postsave'])) {
+			foreach($this->listeners['upload.postsave'] as $handler)
+				call_user_func_array($handler, array(&$result, $this));
+		} 	
+		
 		return $result;
 	}
 		


### PR DESCRIPTION
Hello,

Working on many plugins projects for elFinder it came necessary to acces uploaded data before returning to the client.

For instance, i created a plugin that always create a .jpeg clone of non jpeg files to obtain an optimized version.

So i suggest to bind plugins on after ulpoad just passing the results array and elFinder instance.

Regards