### PR TITLE
Wrong translation - btnRm

### DIFF
--- a/js/i18n/elfinder.sr.js
+++ b/js/i18n/elfinder.sr.js
@@ -133,7 +133,7 @@
 			/*********************************** buttons ***********************************/ 
 			'btnClose'  : 'Zatvori',
 			'btnSave'   : 'Sačuvaj',
-			'btnRm'     : 'Preimenuj',
+			'btnRm'     : 'Obriši',
 			'btnApply'  : 'Potvrdi',
 			'btnCancel' : 'Prekini',
 			'btnNo'     : 'Ne',


### PR DESCRIPTION
Misleading translation - Preimenuj is "Rename" in Serbian.