### PR TITLE
The search doesn't retrieve the files when the name of the file starts with the searched word.

### DIFF
--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -6046,7 +6046,7 @@ abstract class elFinderVolumeDriver {
 	 * @return @return bool
 	 */
 	protected function searchMatchName($name , $query , $path) {
-		return (bool)$this->stripos($name , $query);
+		return $this->stripos($name , $query) !== false;
 	}
 
 	/**


### PR DESCRIPTION
The search doesn't retrieve the files when the name of the file starts with the searched word, only for the driver like FTP that doesn't have a doSearch implementation.
For example when we call the method "searchMatchName" If the parameter $query is equal to $name the conversion of 0 into bool returns erroneously false.
This PR resolve it. 
Thanks.