### PR TITLE
Fix hash@undefined on select folder upload

### DIFF
--- a/php/plugins/Normalizer/plugin.php
+++ b/php/plugins/Normalizer/plugin.php
@@ -138,6 +138,8 @@ class elFinderPluginNormalizer extends elFinderPlugin
 				foreach($result['hashes'] as $name => $hash) {
 					if ($keys = array_keys($this->replaced['mkdir'], $name)) {
 						$result['hashes'][$keys[0]] = $hash;
+					} elseif ($keys = array_keys($this->replaced['mkdir'], ltrim($name, '/'))) {
+						$result['hashes']['/' . $keys[0]] = $hash;
 					}
 				}
 			}


### PR DESCRIPTION
When upload using 'Select folder' and Normalizer plugin enabling.
On command "mkdir"  preprocessing-folder names ($args['dirs']) passed without starting slashes-"folder/subfolder"
but on postprocess -$result['hashes'] has keys with start slashes - "/folder/subfolder"
because of this Normalizer function cant obtain keys from replaced array