### PR TITLE
[VD:Dropbox2] fix options definition test

### DIFF
--- a/php/elFinderVolumeDropbox2.class.php
+++ b/php/elFinderVolumeDropbox2.class.php
@@ -464,8 +464,8 @@ class elFinderVolumeDropbox2 extends elFinderVolumeDriver
     /*********************************************************************/
 
     /**
-     * Prepare FTP connection
-     * Connect to remote server and check if credentials are correct, if so, store the connection id in $ftp_conn.
+     * Prepare Dropbox connection
+     * Connect to remote server and check if credentials are correct, if so, store the connection id in $this->service.
      *
      * @return bool
      *

--- a/php/elFinderVolumeDropbox2.class.php
+++ b/php/elFinderVolumeDropbox2.class.php
@@ -473,14 +473,14 @@ class elFinderVolumeDropbox2 extends elFinderVolumeDriver
      **/
     protected function init()
     {
-        if (empty($options['app_key'])) {
+        if (empty($this->options['app_key'])) {
             if (defined('ELFINDER_DROPBOX_APPKEY') && ELFINDER_DROPBOX_APPKEY) {
                 $this->options['app_key'] = ELFINDER_DROPBOX_APPKEY;
             } else {
                 return $this->setError('Required option "app_key" is undefined.');
             }
         }
-        if (empty($options['app_secret'])) {
+        if (empty($this->options['app_secret'])) {
             if (defined('ELFINDER_DROPBOX_APPSECRET') && ELFINDER_DROPBOX_APPSECRET) {
                 $this->options['app_secret'] = ELFINDER_DROPBOX_APPSECRET;
             } else {


### PR DESCRIPTION
The empty test an undefined variable. I think it should test the `options` property instead.

Updated it in a symfony project, it works a lot better :wink: 
