### PR TITLE
check manual config for archivers before auto detect in getArchivers() function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":        "studio-42/elfinder",
+    "name":        "seekerliu/elfinder",
     "description": "File manager for web",
     "license":     "BSD-3-Clause",
     "homepage":    "http://elfinder.org",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":        "seekerliu/elfinder",
+    "name":        "studio-42/elfinder",
     "description": "File manager for web",
     "license":     "BSD-3-Clause",
     "homepage":    "http://elfinder.org",

--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -6112,7 +6112,7 @@ abstract class elFinderVolumeDriver {
 	protected function getArchivers($use_cache = true) {
 		if(!empty($this->options['archivers']) && is_array($this->options['archivers']))
 		    return $this->options['archivers'];
-		
+
 		$sessionKey = 'ARCHIVERS_CACHE';
 		if ($use_cache && isset($this->sessionCache[$sessionKey]) && is_array($this->sessionCache[$sessionKey])) {
 			return $this->sessionCache[$sessionKey];

--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -6110,10 +6110,10 @@ abstract class elFinderVolumeDriver {
 	 * @return array
 	 */
 	protected function getArchivers($use_cache = true) {
-        if(!empty($this->options['archivers']) && is_array($this->options['archivers']))
-            return $this->options['archivers'];
-
-        $sessionKey = 'ARCHIVERS_CACHE';
+		if(!empty($this->options['archivers']) && is_array($this->options['archivers']))
+		    return $this->options['archivers'];
+		
+		$sessionKey = 'ARCHIVERS_CACHE';
 		if ($use_cache && isset($this->sessionCache[$sessionKey]) && is_array($this->sessionCache[$sessionKey])) {
 			return $this->sessionCache[$sessionKey];
 		}

--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -6110,8 +6110,9 @@ abstract class elFinderVolumeDriver {
 	 * @return array
 	 */
 	protected function getArchivers($use_cache = true) {
-		if(!empty($this->options['archivers']) && is_array($this->options['archivers']))
-		    return $this->options['archivers'];
+		if (!empty($this->options['archivers']) && is_array($this->options['archivers'])) {
+			return $this->options['archivers'];
+		}
 
 		$sessionKey = 'ARCHIVERS_CACHE';
 		if ($use_cache && isset($this->sessionCache[$sessionKey]) && is_array($this->sessionCache[$sessionKey])) {

--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -6110,8 +6110,10 @@ abstract class elFinderVolumeDriver {
 	 * @return array
 	 */
 	protected function getArchivers($use_cache = true) {
+        if(!empty($this->options['archivers']) && is_array($this->options['archivers']))
+            return $this->options['archivers'];
 
-		$sessionKey = 'ARCHIVERS_CACHE';
+        $sessionKey = 'ARCHIVERS_CACHE';
 		if ($use_cache && isset($this->sessionCache[$sessionKey]) && is_array($this->sessionCache[$sessionKey])) {
 			return $this->sessionCache[$sessionKey];
 		}


### PR DESCRIPTION
In `elFinderVolumeDriver.class.php` says user can custom archivers in config, but the `getArchivers()` function did not check the manual config. 