### PR TITLE
add cwd to procExec method.

### DIFF
--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -5772,7 +5772,8 @@ abstract class elFinderVolumeDriver {
 			2 => array("pipe", "w")   // stderr
 		);
 
-		$process = proc_open($command, $descriptorspec, $pipes, null, null);
+        $cwd = getcwd();
+		$process = proc_open($command, $descriptorspec, $pipes, $cwd, null);
 
 		if (is_resource($process)) {
 			stream_set_blocking($pipes[1], 0);

--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -5772,7 +5772,7 @@ abstract class elFinderVolumeDriver {
 			2 => array("pipe", "w")   // stderr
 		);
 
-        $cwd = getcwd();
+		$cwd = getcwd();
 		$process = proc_open($command, $descriptorspec, $pipes, $cwd, null);
 
 		if (is_resource($process)) {


### PR DESCRIPTION
PHP's `proc_open` function has a default parameter named `cwd`, if  `cwd` param is null , the initial working dir for the command will be the working dir of the current PHP process.

In makeArchive() function writes:
```
$cwd = getcwd();
if (chdir($dir)) {
    foreach($files as $i => $file) {
        $files[$i] = '.'.DIRECTORY_SEPARATOR.basename($file);
    }
    $files = array_map('escapeshellarg', $files);
    
    $cmd = $arc['cmd'].' '.$arc['argc'].' '.escapeshellarg($name).' '.implode(' ', $files);
    $this->procExec($cmd, $o, $c);
    chdir($cwd);
} else {
    return false;
}
```
the working dir has changed to `$dir`, but in some environments `procExec()` 's `proc_open` function get a wrong working dir.
```
// function procExec()
$process = proc_open($command, $descriptorspec, $pipes, null, null);
```
this causes a problem that every create archive command is no working in my webserver(mine:PHP 7.2.10, ubuntu server18.04.1), so I improved `procExec()` function.