### PR TITLE
Fix: TypeError: Cannot read property isroot of undefined on removing directory

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -1400,11 +1400,11 @@ var elFinder = function(elm, opts, bootCallback) {
 	/**
 	 * Return file is root?
 	 * 
-	 * @param  Object  target file object
+	 * @param  Object|null  target file object
 	 * @return Boolean
 	 */
 	this.isRoot = function(file) {
-		return (file.isroot || ! file.phash)? true : false;
+		return file && (file.isroot || !file.phash);
 	};
 	
 	/**


### PR DESCRIPTION
On removing directory this error was pushing to console

```
TypeError: Cannot read property 'isroot' of undefined
    at elFinder.isRoot (app_elfinder.full_3.js:1404)
    at n.Event.<anonymous> (app_elfinder.full_3.js:29982)
    at elFinder.trigger (app_elfinder.full_3.js:2838)
    at trigger (app_elfinder.full_3.js:14331)
    at n.Event.<anonymous> (app_elfinder.full_3.js:16578)
    at elFinder.trigger (app_elfinder.full_3.js:2838)
    at elFinder.self.(anonymous function) [as unlockfiles] (http://localhost/app_dev.php/build/app_elfinder.full_3.js:4082:12)
    at Object.<anonymous> (app_elfinder.full_3.js:32328)
    at j (jquery.js:3099)
    at Object.fireWith [as resolveWith] (jquery.js:3211)
``` 