### PR TITLE
Broken Handling of Certain Hash Characters from elFinder Connector

### DIFF
--- a/js/commands/download.js
+++ b/js/commands/download.js
@@ -39,7 +39,7 @@ elFinder.prototype.commands.download = function() {
 					var f = fm.file(h),
 						res = (! f || (! czipdl && f.mime === 'directory') || ! fm.isCommandEnabled(mixedCmd, h))? false : true;
 					if (f && inExec && ! res) {
-						$('#' + fm.cwdHash2Id(f.hash)).trigger('unselect');
+						$(document.getElementById(fm.cwdHash2Id(f.hash))).trigger('unselect');
 					}
 					return res;
 				});
@@ -55,7 +55,7 @@ elFinder.prototype.commands.download = function() {
 			return $.grep(self.files(hashes), function(f) { 
 				var res = (! f.read || (! zipOn && f.mime == 'directory')) ? false : true;
 				if (inExec && ! res) {
-					$('#' + fm.cwdHash2Id(f.hash)).trigger('unselect');
+					$(document.getElementById(fm.cwdHash2Id(f.hash))).trigger('unselect');
 				}
 				return res;
 			});

--- a/js/commands/edit.js
+++ b/js/commands/edit.js
@@ -1079,7 +1079,7 @@ elFinder.prototype.commands.edit = function() {
 			hashes = $.map(files, function(f) { return f.hash; }),
 			list  = [],
 			editor = opts && opts.editor? opts.editor : null,
-			node = $(opts && opts._currentNode? opts._currentNode : $('#'+ fm.cwdHash2Id(hashes[0]))),
+			node = $(opts && opts._currentNode? opts._currentNode : $(document.getElementById(fm.cwdHash2Id(hashes[0])))),
 			getEditor = function() {
 				var dfd = $.Deferred(),
 					storedId;

--- a/js/commands/quicklook.js
+++ b/js/commands/quicklook.js
@@ -513,7 +513,7 @@
 
 			if (!init && state === closed) {
 				if (file && file.hash !== cwdHash) {
-					node = $('#'+fm.cwdHash2Id(file.hash.split('/', 2)[0]));
+					node = $(document.getElementById(fm.cwdHash2Id(file.hash.split('/', 2)[0])));
 				}
 				navStyle = '';
 				navbar.attr('style', '');

--- a/js/commands/rename.js
+++ b/js/commands/rename.js
@@ -314,7 +314,7 @@ elFinder.prototype.commands.rename = function() {
 			incwd    = (fm.cwd().hash == file.hash),
 			type     = (opts._currentType === 'navbar' || opts._currentType === 'files')? opts._currentType : (incwd? 'navbar' : 'files'),
 			navbar   = (type !== 'files'),
-			target   = $('#'+fm[navbar? 'navHash2Id' : 'cwdHash2Id'](file.hash)),
+			target   = $(document.getElementById(fm[navbar? 'navHash2Id' : 'cwdHash2Id'](file.hash))),
 			tarea    = (!navbar && fm.storage('view') != 'list'),
 			split    = function(name) {
 				var ext = fm.splitFileExtention(name)[1];

--- a/js/commands/upload.js
+++ b/js/commands/upload.js
@@ -309,7 +309,8 @@ elFinder.prototype.commands.upload = function() {
 		}
 		
 		if (targetDir.dirs) {
-			if (targetDir.hash === cwdHash || $('#'+fm.navHash2Id(targetDir.hash)).hasClass('elfinder-subtree-loaded')) {
+			
+			if (targetDir.hash === cwdHash || $(document.getElementById(fm.navHash2Id(targetDir.hash))).hasClass('elfinder-subtree-loaded')) {
 				getSelector().appendTo(dialog);
 			} else {
 				spinner = $('<div class="elfinder-upload-dirselect" title="' + fm.i18n('nowLoading') + '"/>')

--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -324,13 +324,13 @@ var elFinder = function(elm, opts, bootCallback) {
 					var isDir = (files[i].mime === 'directory'),
 						phash = files[i].phash,
 						pnav;
-					
+						
 					if (
 						(!isDir
 							|| emptyDirs[phash]
 							|| (!stayDirs[phash]
-								&& $('#'+self.navHash2Id(files[i].hash)).is(':hidden')
-								&& $('#'+self.navHash2Id(phash)).next('.elfinder-navbar-subtree').children().length > 100
+								&& $(document.getElementById(self.navHash2Id(files[i].hash))).is(':hidden')
+								&& $(document.getElementById(self.navHash2Id(phash))).next('.elfinder-navbar-subtree').children().length > 100
 							)
 						)
 						&& (isDir || phash !== cwd)
@@ -338,7 +338,7 @@ var elFinder = function(elm, opts, bootCallback) {
 					) {
 						if (isDir && !emptyDirs[phash]) {
 							emptyDirs[phash] = true;
-							$('#'+self.navHash2Id(phash))
+							$(document.getElementById(self.navHash2Id(phash)))
 							 .removeClass(rmClass)
 							 .next('.elfinder-navbar-subtree').empty();
 						}
@@ -9014,7 +9014,7 @@ elFinder.prototype = {
 		
 		$.each(files, function(i, f) {
 			if (f.phash === cwdHash || self.searchStatus.state > 1) {
-				newItem = newItem.add(cwd.find('#'+self.cwdHash2Id(f.hash)));
+				newItem = newItem.add(document.getElementById(self.cwdHash2Id(f.hash)));
 				if (opts.firstOnly) {
 					return false;
 				}

--- a/js/elFinder.resources.js
+++ b/js/elFinder.resources.js
@@ -137,7 +137,7 @@ elFinder.prototype.resources = {
 					move  : move
 				},
 				data = this.data || {},
-				node = ui.trigger('create.'+fm.namespace, file).find('#'+fm[find](id)),
+				node = ui.trigger('create.'+fm.namespace, file).find(document.getElementById(fm[find](id))),
 				nnode, pnode,
 				overlay = fm.getUI('overlay'),
 				cleanup = function() {
@@ -263,7 +263,7 @@ elFinder.prototype.resources = {
 										if (data && data.added && data.added[0]) {
 											var item    = data.added[0],
 												dirhash = item.hash,
-												newItem = ui.find('#'+fm[find](dirhash)),
+												newItem = ui.find(document.getElementById(fm[find](dirhash))),
 												acts    = {
 													'directory' : { cmd: 'open', msg: 'cmdopendir' },
 													'text'      : { cmd: 'edit', msg: 'cmdedit' },
@@ -334,7 +334,7 @@ elFinder.prototype.resources = {
 			}
 			
 			if (tree) {
-				dst = $('#'+fm[find](phash));
+				dst = $(document.getElementById(fm[find](phash)));
 				collapsed = fm.res('class', 'navcollapse');
 				expanded  = fm.res('class', 'navexpand');
 				arrow = fm.res('class', 'navarrow');

--- a/js/ui/contextmenu.js
+++ b/js/ui/contextmenu.js
@@ -677,7 +677,7 @@ $.fn.elfindercontextmenu = function(fm) {
 				if (sel.length) {
 					type = 'files';
 					targets = sel;
-					elm = $('#'+fm.cwdHash2Id(sel[0]));
+					elm = $(document.getElementById(fm.cwdHash2Id(sel[0])));
 				} else {
 					type = 'cwd';
 					targets = [ fm.cwd().hash ];

--- a/js/ui/cwd.js
+++ b/js/ui/cwd.js
@@ -459,7 +459,7 @@ $.fn.elfindercwd = function(fm, options) {
 			selectedFiles = {},
 			
 			selectFile = function(hash) {
-				$('#'+fm.cwdHash2Id(hash)).trigger(evtSelect);
+				$(document.getElementById(fm.cwdHash2Id(hash))).trigger(evtSelect);
 			},
 			
 			allSelected = false,
@@ -477,7 +477,7 @@ $.fn.elfindercwd = function(fm, options) {
 						selectedFiles = {};
 						$.each(files, function(i, v) {
 							selectedFiles[v.hash] = true;
-							$('#'+fm.cwdHash2Id(v.hash)).trigger(evtSelect);
+							$(document.getElementById(fm.cwdHash2Id(v.hash))).trigger(evtSelect);
 						});
 						fm.toast({mode: 'warning', msg: fm.i18n(['errMaxTargets', fm.maxTargets])});
 					} else {
@@ -517,7 +517,7 @@ $.fn.elfindercwd = function(fm, options) {
 					selectAll();
 				} else {
 					$.each((incHashes || cwdHashes), function(i, h) {
-						var itemNode = $('#'+fm.cwdHash2Id(h));
+						var itemNode = $(document.getElementById(fm.cwdHash2Id(h)));
 						if (! selectedFiles[h]) {
 							invHashes[h] = true;
 							itemNode.length && itemNode.trigger(evtSelect);
@@ -1226,7 +1226,7 @@ $.fn.elfindercwd = function(fm, options) {
 							.attr('src', tmb.url);
 					},
 					chk  = function(hash, tmb) {
-						var node = $('#'+fm.cwdHash2Id(hash)),
+						var node = $(document.getElementById(fm.cwdHash2Id(hash))),
 							file, tmbObj, reloads = [];
 	
 						if (node.length) {
@@ -1394,7 +1394,7 @@ $.fn.elfindercwd = function(fm, options) {
 						file = files[l];
 						hash = file.hash;
 						
-						if ($('#'+fm.cwdHash2Id(hash)).length) {
+						if ($(document.getElementById(fm.cwdHash2Id(hash))).length) {
 							continue;
 						}
 						
@@ -1414,7 +1414,7 @@ $.fn.elfindercwd = function(fm, options) {
 							}
 						}
 						
-						if ($('#'+fm.cwdHash2Id(hash)).length) {
+						if ($(document.getElementById(fm.cwdHash2Id(hash))).length) {
 							if ((file.tmb && (file.tmb != 1 || file.size > 0)) || (stmb && file.mime.indexOf('image/') === 0)) {
 								atmb[hash] = file.tmb || 'self';
 							}
@@ -1462,7 +1462,7 @@ $.fn.elfindercwd = function(fm, options) {
 				
 				while (l--) {
 					hash = files[l];
-					if ((n = $('#'+fm.cwdHash2Id(hash))).length) {
+					if ((n = $(document.getElementById(fm.cwdHash2Id(hash)))).length) {
 						try {
 							n.remove();
 							--bufferExt.renderd;
@@ -2177,7 +2177,7 @@ $.fn.elfindercwd = function(fm, options) {
 				// unselect all selected files
 				.on('unselectall', unselectAll)
 				.on('selectfile', function(e, id) {
-					$('#'+fm.cwdHash2Id(id)).trigger(evtSelect);
+					$(document.getElementById(fm.cwdHash2Id(id))).trigger(evtSelect);
 					trigger();
 				})
 				.on('colwidth', function() {
@@ -2730,7 +2730,7 @@ $.fn.elfindercwd = function(fm, options) {
 
 				if (query) {
 					$.each(e.data.changed || [], function(i, file) {
-						if ($('#'+fm.cwdHash2Id(file.hash)).length) {
+						if ($(document.getElementById(fm.cwdHash2Id(file.hash))).length) {
 							remove([file.hash]);
 							add([file], 'change');
 							$.inArray(file.hash, sel) !== -1 && selectFile(file.hash);
@@ -2739,7 +2739,7 @@ $.fn.elfindercwd = function(fm, options) {
 					});
 				} else {
 					$.each($.grep(e.data.changed || [], function(f) { return f.phash == phash ? true : false; }), function(i, file) {
-						if ($('#'+fm.cwdHash2Id(file.hash)).length) {
+						if ($(document.getElementById(fm.cwdHash2Id(file.hash))).length) {
 							remove([file.hash]);
 							add([file], 'change');
 							$.inArray(file.hash, sel) !== -1 && selectFile(file.hash);
@@ -2827,7 +2827,7 @@ $.fn.elfindercwd = function(fm, options) {
 				if (!helper.data('locked')) {
 					while (l--) {
 						try {
-							$('#'+fm.cwdHash2Id(files[l])).trigger(event);
+							$(document.getElementById(fm.cwdHash2Id(files[l]))).trigger(event);
 						} catch(e) {}
 					}
 					! e.data.inselect && trigger();

--- a/js/ui/searchbutton.js
+++ b/js/ui/searchbutton.js
@@ -296,7 +296,7 @@ $.fn.elfindersearchbutton = function(cmd) {
 					var code = e.originalEvent.keyCode,
 						next = function() {
 							var sel = fm.selected(),
-								key = $.ui.keyCode[(!sel.length || $('#'+fm.cwdHash2Id(sel[0])).next('[id]').length)? 'RIGHT' : 'HOME'];
+								key = $.ui.keyCode[(!sel.length || $(document.getElementById(fm.cwdHash2Id(sel[0]))).next('[id]').length)? 'RIGHT' : 'HOME'];
 							$(document).trigger($.Event('keydown', { keyCode: key, ctrlKey : false, shiftKey : false, altKey : false, metaKey : false }));
 						},
 						val;

--- a/js/ui/tree.js
+++ b/js/ui/tree.js
@@ -208,7 +208,7 @@ $.fn.elfindertree = function(fm, opts) {
 					}).done(function(res) {
 						if (res && res.subdirs) {
 							$.each(res.subdirs, function(hash, subdirs) {
-								var elm = $('#'+fm.navHash2Id(hash));
+								var elm = $(document.getElementById(fm.navHash2Id(hash)));
 								elm.removeClass(chksubdir);
 								elm[subdirs? 'addClass' : 'removeClass'](collapsed);
 							});
@@ -453,7 +453,7 @@ $.fn.elfindertree = function(fm, opts) {
 			 */
 			filter = function(files, checkExists) {
 				return $.map(files || [], function(f) {
-					return (f.mime === 'directory' && (!checkExists || $('#'+fm.navHash2Id(f.hash)).length)) ? f : null;
+					return (f.mime === 'directory' && (!checkExists || $(document.getElementById(fm.navHash2Id(f.hash))).length)) ? f : null;
 				});
 			},
 			
@@ -464,7 +464,7 @@ $.fn.elfindertree = function(fm, opts) {
 			 * @return jQuery
 			 */
 			findSubtree = function(hash) {
-				return hash ? $('#'+fm.navHash2Id(hash)).next('.'+subtree) : tree;
+				return hash ? $(document.getElementById(fm.navHash2Id(hash))).next('.'+subtree) : tree;
 			},
 			
 			/**
@@ -638,7 +638,7 @@ $.fn.elfindertree = function(fm, opts) {
 								detach();
 								parent.empty()[parts? 'addClass' : 'removeClass']('elfinder-navbar-hasmore').append(prevBtn, html.join(''), nextBtn);
 								$.each(nodes, function(h, n) {
-									$('#'+fm.navHash2Id(h)).parent().replaceWith(n);
+									$(document.getElementById(fm.navHash2Id(h))).parent().replaceWith(n);
 								});
 								if (direction) {
 									autoScroll(fm.navHash2Id(parts[direction === 'up'? parts.length - 1 : 0].hash));
@@ -667,7 +667,7 @@ $.fn.elfindertree = function(fm, opts) {
 				while (i--) {
 					dir = dirs[i];
 
-					if (done[dir.hash] || $('#'+fm.navHash2Id(dir.hash)).length) {
+					if (done[dir.hash] || $(document.getElementById(fm.navHash2Id(dir.hash))).length) {
 						continue;
 					}
 					done[dir.hash] = true;
@@ -693,7 +693,7 @@ $.fn.elfindertree = function(fm, opts) {
 							parent[firstVol || dir.phash ? 'append' : 'prepend'](node);
 							firstVol = false;
 							if (!dir.phash || dir.isroot) {
-								base = $('#'+fm.navHash2Id(dir.hash)).parent();
+								base = $(document.getElementById(fm.navHash2Id(dir.hash))).parent();
 							}
 							! mobile && updateDroppable(null, base);
 						}
@@ -763,7 +763,7 @@ $.fn.elfindertree = function(fm, opts) {
 					current, parent, top, treeH, bottom, tgtTop;
 				autoScrTm && clearTimeout(autoScrTm);
 				autoScrTm = setTimeout(function() {
-					current = $('#'+(target || fm.navHash2Id(fm.cwd().hash)));
+					current = $(document.getElementById((target || fm.navHash2Id(fm.cwd().hash))));
 					if (current.length) {
 						// expand parents directory
 						(openCwd? current : current.parent()).parents('.elfinder-navbar-wrapper').children('.'+loaded).addClass(expanded).next('.'+subtree).show();
@@ -807,7 +807,7 @@ $.fn.elfindertree = function(fm, opts) {
 					res.unshift(phash);
 					root = fm.root(phash);
 					dir = fm.file(root);
-					if ($('#'+fm.navHash2Id(dir.hash)).hasClass(loaded)) {
+					if ($(document.getElementById(fm.navHash2Id(dir.hash))).hasClass(loaded)) {
 						break;
 					}
 				}
@@ -824,16 +824,16 @@ $.fn.elfindertree = function(fm, opts) {
 			selectPages = function(current) {
 				var cur = current || fm.cwd(),
 					curHash = cur.hash,
-					node = $('#'+fm.navHash2Id(curHash));
+					node = $(document.getElementById(fm.navHash2Id(curHash)));
 			
 				if (!node.length) {
 					while(cur && cur.phash) {
-						if (hasMoreDirs[cur.phash] && !$('#'+fm.navHash2Id(cur.hash)).length) {
+						if (hasMoreDirs[cur.phash] && !$(document.getElementById(fm.navHash2Id(cur.hash))).length) {
 							hasMoreDirs[cur.phash].trigger('update.'+fm.namespace, { select : cur.hash });
 						}
 						cur = fm.file(cur.phash);
 					}
-					node = $('#'+fm.navHash2Id(curHash));
+					node = $(document.getElementById(fm.navHash2Id(curHash)));
 				}
 				
 				return node;
@@ -880,7 +880,7 @@ $.fn.elfindertree = function(fm, opts) {
 						reqs = $.map(ends, function(h) {
 							var d = fm.file(h),
 								isRoot = d? fm.isRoot(d) : false,
-								node = $('#'+fm.navHash2Id(h)),
+								node = $(document.getElementById(fm.navHash2Id(h))),
 								getPhash = function(h, dep) {
 									var d, ph,
 										depth = dep || 1;
@@ -895,7 +895,7 @@ $.fn.elfindertree = function(fm, opts) {
 									var phash = getPhash(h);
 									until = phash;
 									while (phash) {
-										if ($('#'+fm.navHash2Id(phash)).hasClass(loaded)) {
+										if ($(document.getElementById(fm.navHash2Id(phash))).hasClass(loaded)) {
 											break;
 										}
 										until = phash;
@@ -909,7 +909,7 @@ $.fn.elfindertree = function(fm, opts) {
 								})(),
 								cmd;
 							
-							if (!node.hasClass(loaded) && (isRoot || !d || !$('#'+fm.navHash2Id(d.phash)).hasClass(loaded))) {
+							if (!node.hasClass(loaded) && (isRoot || !d || !$(document.getElementById(fm.navHash2Id(d.phash))).hasClass(loaded))) {
 								if (isRoot || closest === getPhash(h) || closest === getPhash(h, 2)) {
 									until = void(0);
 									cmd = 'tree';
@@ -1012,7 +1012,7 @@ $.fn.elfindertree = function(fm, opts) {
 					dfrd = $.Deferred(),
 					baseNode, spinner;
 				
-				if (!$('#'+fm.navHash2Id(cwdhash)).length) {
+				if (!$(document.getElementById(fm.navHash2Id(cwdhash))).length) {
 					syncing = true;
 					loadParents()
 					.done(function(res) {
@@ -1086,7 +1086,7 @@ $.fn.elfindertree = function(fm, opts) {
 						: ':not(.'+collapsed+')';
 				
 				$.each(dirs, function(i, dir) {
-					$('#'+fm.navHash2Id(dir.phash)+sel)
+					$(document.getElementById(fm.navHash2Id(dir.phash))).filter(sel)
 						.filter(function() { return $.grep($(this).next('.'+subtree).children(), function(n) {
 							return ($(n).children().hasClass(root))? false : true;
 						}).length > 0; })
@@ -1376,7 +1376,7 @@ $.fn.elfindertree = function(fm, opts) {
 			while (l--) {
 				dir = dirs[l];
 				phash = dir.phash;
-				if ((node = $('#'+fm.navHash2Id(dir.hash))).length) {
+				if ((node = $(document.getElementById(fm.navHash2Id(dir.hash)))).length) {
 					parent = node.parent();
 					if (phash) {
 						realParent  = node.closest('.'+subtree);
@@ -1400,7 +1400,7 @@ $.fn.elfindertree = function(fm, opts) {
 					
 					if (dir.dirs
 					&& (isExpanded || isLoaded) 
-					&& (node = $('#'+fm.navHash2Id(dir.hash))) 
+					&& (node = $(document.getElementById(fm.navHash2Id(dir.hash))))
 					&& node.next('.'+subtree).children().length) {
 						isExpanded && node.addClass(expanded);
 						isLoaded && node.addClass(loaded);
@@ -1433,7 +1433,7 @@ $.fn.elfindertree = function(fm, opts) {
 			});
 
 			while (l--) {
-				if ((node = $('#'+fm.navHash2Id(dirs[l]))).length) {
+				if ((node = $(document.getElementById(fm.navHash2Id(dirs[l])))).length) {
 					removed = true;
 					stree = node.closest('.'+subtree);
 					node.parent().detach();
@@ -1460,7 +1460,7 @@ $.fn.elfindertree = function(fm, opts) {
 				});
 				
 			$.each(dirs, function(i, hash) {
-				var dir = $('#'+fm.navHash2Id(hash));
+				var dir = $(document.getElementById(fm.navHash2Id(hash)));
 				
 				if (dir.length && !helperLocked) {
 					dir.hasClass(draggable) && dir.draggable(act);


### PR DESCRIPTION
In the elFinder [docs](https://github.com/Studio-42/elFinder/wiki/Client-Server-API-2.1#file-paths-hashes), it has the below content:

> Using this algorithm even without encryption, client cannot get real file paths on the server only relative to root paths. This hash algorithm is recommended but you can use your own implementation so long as it matches these 2 rules:
> 
> hash must be valid for storage in the id attribute of an HTML tag
> hash must be reversible by connector

This doesn't actually hold as characters such as ".", ":" are [valid HTML ID characters](https://stackoverflow.com/questions/70579/what-are-valid-values-for-the-id-attribute-in-html), but when used in a JQuery hash selector, elFinder would behave strangely as internally, it does it in such a way where these characters are confused with CSS/JQuery selector characters instead of being part of the HTML ID.

For more information on the above issue, refer to the accepted answer on this [stackoverflow post](https://stackoverflow.com/questions/70579/what-are-valid-values-for-the-id-attribute-in-html).

As such, I've made a pull request in an attempt to solve the above issue. So essentially, instead of:
```
$("#" + elementId)
```
It now uses:
```
$(document.getElementById(elementId))
```

**Benchmark**

I ran a small benchmark to see any performance difference, and it turns out using $(document.getElementById("<ElementId>")) is actually faster.

I copied the code within this text file and ran it on the [elfinder demo page](https://studio-42.github.io/elFinder/#elf_l1_Lw).
[Benchmark.txt](https://github.com/Studio-42/elFinder/files/2684138/Benchmark.txt)

**Benchmark Results**

![benchmark](https://user-images.githubusercontent.com/9282390/50061424-6d5d7480-01f4-11e9-9850-f08f1e2ac0e1.PNG)

