### PR TITLE
No way to execute this part of code

### DIFF
--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -1029,14 +1029,6 @@ class elFinder
         $dst = !empty($args['target']) ? $args['target'] : (!empty($args['dst']) ? $args['dst'] : '');
         if ($dst) {
             $dstVolume = $this->volume($dst);
-        } else if (isset($args['targets']) && is_array($args['targets']) && isset($args['targets'][0])) {
-            $dst = $args['targets'][0];
-            $dstVolume = $this->volume($dst);
-            if ($dstVolume && ($_stat = $dstVolume->file($dst)) && !empty($_stat['phash'])) {
-                $dst = $_stat['phash'];
-            } else {
-                $dst = '';
-            }
         } else if ($cmd === 'open') {
             // for initial open without args `target`
             $dstVolume = $this->default;


### PR DESCRIPTION
I'm can't find case where this part of code will be executed. This code should be executed only if `$args['target']` is non empty array, but in that case on line 1029 behind variable `$dst` will be set, so line 1032 will be skipped.
Sorry if i'm missed something there.