### PR TITLE
Fix CustomData to Thumbnail URL

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -2111,12 +2111,12 @@ var elFinder = function(elm, opts, bootCallback) {
 			}
 			if (url) {
 				if (file.ts && tmbUrl !== 'self') {
-                    url += (url.match(/\?/) ? '&' : '?') + '_t=' + file.ts;
-                    if (this.customData) {
-                        $.each(this.customData, function (key, val) {
-                            url += '&' + encodeURIComponent(key) + '=' + encodeURIComponent(val);
-                        });
-                    }
+					url += (url.match(/\?/) ? '&' : '?') + '_t=' + file.ts;
+					if (this.customData) {
+						$.each(this.customData, function (key, val) {
+							url += '&' + encodeURIComponent(key) + '=' + encodeURIComponent(val);
+						});
+					}
 				}
 				return { url: url, className: cls };
 			}

--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -2111,7 +2111,12 @@ var elFinder = function(elm, opts, bootCallback) {
 			}
 			if (url) {
 				if (file.ts && tmbUrl !== 'self') {
-					url += (url.match(/\?/)? '&' : '?') + '_t=' + file.ts;
+                    url += (url.match(/\?/) ? '&' : '?') + '_t=' + file.ts;
+                    if (this.customData) {
+                        $.each(this.customData, function (key, val) {
+                            url += '&' + encodeURIComponent(key) + '=' + encodeURIComponent(val);
+                        });
+                    }
 				}
 				return { url: url, className: cls };
 			}


### PR DESCRIPTION
Sorry about not providing a full use case for this issue, but its clear to see..
If you use customData on client settings, customData params is only used when fetching data from connector URL. 
If you have a usecase where one or more of these customData params defines the root of connector, thumbnail URL also needs these params to provide correct thumbnail.
