### PR TITLE
Fix invalid grant bad request

### DIFF
--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -3923,7 +3923,7 @@ class elFinder
             }
             $script .= 'window.close();';
 
-            $out = '<!DOCTYPE html><html><head><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"><meta http-equiv="Content-Type" content="text/html; charset=utf-8"><script>' . $script . '</script></head><body><a href="#" onlick="window.close();return false;">Close this window</a></body></html>';
+            $out = '<!DOCTYPE html><html><head><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"><meta http-equiv="Content-Type" content="text/html; charset=utf-8"><script>' . $script . '</script></head><body><a href="#" onclick="window.close();return false;">Close this window</a></body></html>';
 
             header('Content-Type: text/html; charset=utf-8');
             header('Content-Length: ' . strlen($out));


### PR DESCRIPTION
Hello @nao-pon,

Regardless of the problem with composer ( #3033 ), I have copied the dependencies of a previous version, and it works correctly.

However, when I try to connect to Google Drive it gives me "errReauthRequire". I have located that this error occurs because authentication failed with the "invalid_grant - Bad Request" error (id_client, secret_id and include autoload are good).

I have corrected it and get the token.

But the whole process stands still in this return (elFinderFlysystemGoogleDriveNetmount.php) :

```
            if (!empty($_GET['code']) && !$aToken) {
                $aToken = $client->fetchAccessTokenWithAuthCode($_GET['code']);
                $options['access_token'] = $aToken['access_token'];
                $this->session->set('GoogleDriveTokens', $aToken['access_token'])->set('GoogleDriveAuthParams', $options);
                $out = array(
                    'node' => $options['id'],
                    'json' => '{"protocol": "googledrive", "mode": "done", "reset": 1}',
                    'bind' => 'netmount'
                );
                return array('exit' => 'callback', 'out' => $out);
            }
```
Once the callback is executed, a page with a "Close this Window" is displayed and does nothing else.

I understand that at this point, the new window should close and reload elFinder to show the Google Drive driver, is that so?

I have also observed that the session data is deleted, when they should be maintained in order to perform that elFinder reload, right?.

I hope your help, thanks.