### PR TITLE
Update dialog.css

### DIFF
--- a/css/dialog.css
+++ b/css/dialog.css
@@ -188,6 +188,7 @@
     -moz-user-select: text;
     -khtml-user-select: text;
     user-select: text;
+    padding-left: 55px !important;
 }
 
 .elfinder .std42-dialog .ui-dialog-content label {


### PR DESCRIPTION

![elfinder_message_window](https://user-images.githubusercontent.com/1905204/70474649-4bc75e00-1ad3-11ea-8e4a-fcf513550568.png)
Because value of jquery-ui.min.css is used, the icon is displayed over the text (or text under the icon).