### PR TITLE
Fix PHP7.4 deprecation error

### DIFF
--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -2611,7 +2611,7 @@ class elFinder
                     $_url = $url;
                     $url = trim($matches[1]);
                     if (!preg_match('/^https?:\//', $url)) { // no scheme
-                        if ($url{0} != '/') { // Relative path
+                        if ($url[0] != '/') { // Relative path
                             // to Absolute path
                             $url = substr($url_path, 0, strrpos($url_path, '/')) . '/' . $url;
                         }


### PR DESCRIPTION
PHP 7.4 deprecated the use of curly braces to access array/string indexes resulting in errors like this:
`ErrorException  : Array and string offset access syntax with curly braces is deprecated`

This change makes the code compatible with PHP7.4.

For more information on the deprecation see: https://wiki.php.net/rfc/deprecate_curly_braces_array_access