### PR TITLE
Wrong dialog sizing with dialogContained=true

### DIFF
--- a/js/ui/dialog.js
+++ b/js/ui/dialog.js
@@ -103,14 +103,10 @@ $.fn.elfinderdialog = function(opts, fm) {
 		opts.allowMinimize = false;
 	}
 	
-	if (fm.options.dialogContained) {
-		syncSize.width = syncSize.height = syncSize.enabled = true;
-	} else {
-		syncSize.width = (opts.maxWidth === 'window');
-		syncSize.height = (opts.maxHeight === 'window');
-		if (syncSize.width || syncSize.height) {
-			syncSize.enabled = true;
-		}
+	syncSize.width = (opts.maxWidth === 'window');
+	syncSize.height = (opts.maxHeight === 'window');
+	if (syncSize.width || syncSize.height) {
+		syncSize.enabled = true;
 	}
 
 	propagationEvents = fm.arrayFlip(opts.propagationEvents, true);


### PR DESCRIPTION
When dialogContained is true dialog sizing 
syncSize.width = syncSize.height = syncSize.enabled = true; 
works wrong way, because dialogs windows are maximized by height.