### PR TITLE
Update cookieEnabled check

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -5810,14 +5810,7 @@ elFinder.prototype = {
 	 * 
 	 * @type Boolean
 	 */
-	cookieEnabled : (function() {
-		var res = false,
-			test = 'elftest=';
-		document.cookie = test + '1';
-		res = document.cookie.split(test).length === 2;
-		document.cookie = test + ';max-age=0';
-		return res;
-	})(),
+	cookieEnabled : window.navigator.cookieEnabled,
 
 	/**
 	 * Has RequireJS?


### PR DESCRIPTION
Hello.

This check is a reason for a warning in modern browsers since SameSite attribute is not set. I believe it can be replaced with a call to navigator API.