### PR TITLE
Upload bug

### DIFF
--- a/js/commands/upload.js
+++ b/js/commands/upload.js
@@ -194,10 +194,17 @@ elFinder.prototype.commands.upload = function() {
 				data = null,
 				target = e._target || null,
 				trf = e.dataTransfer || null,
-				kind = (trf.items && trf.items.length && trf.items[0].kind)? trf.items[0].kind : '',
+				kind = '',
 				errors;
 			
 			if (trf) {
+				if (trf.types && trf.types.length && $.inArray('Files', trf.types) !== -1) {
+				    kind = 'file';
+				}
+				else if (trf.items && trf.items.length && trf.items[0].kind) {
+				    kind = trf.items[0].kind;
+				}
+
 				try {
 					elfFrom = trf.getData('elfinderfrom');
 					if (elfFrom) {


### PR DESCRIPTION
Fixes https://github.com/Studio-42/elFinder/issues/3262.  I think this could be related to [Issue 155455: item.webkitGetAsEntry().file() reports an empty file type](https://bugs.chromium.org/p/chromium/issues/detail?id=155455).

Fix uses [DataTransfer.types](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/types) array to establish if transfer is a file.

> An array of the data formats used in the drag operation. Each format is string. If the drag operation included no data, this list will be empty. If any files are included in the drag operation, then one of the types will be the string Files.