### PR TITLE
Option to pass url to request function

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -2323,7 +2323,7 @@ var elFinder = function(elm, opts, bootCallback) {
 			useCache = (opts.options || {}).cache,
 			// request options
 			options = Object.assign({
-				url      : o.url,
+				url      : opts.url || o.url,
 				async    : true,
 				type     : this.requestType,
 				dataType : 'json',


### PR DESCRIPTION
While investigating `commandsOptions.info.custom` it would be good to allow action to pass `fm.request` a url option to override the default url in options.

https://github.com/Studio-42/elFinder/blob/33eea861cb07196edbde5d9188f65a6ce81be21f/js/elFinder.options.js#L651-L662