### PR TITLE
replace space with underscore in file name

### DIFF
--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -2441,6 +2441,7 @@ abstract class elFinderVolumeDriver
      */
     public function upload($fp, $dst, $name, $tmpname, $hashes = array())
     {
+        $name = str_replace(' ','_',$name);
         if ($this->commandDisabled('upload')) {
             return $this->setError(elFinder::ERROR_PERM_DENIED);
         }


### PR DESCRIPTION
In some cases, if there is a space in the file name then the URL is not working. So we need a file URL without space.