### PR TITLE
Enable drag when copy or cut enabled

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -5182,7 +5182,9 @@ var elFinder = function(elm, opts, bootCallback) {
 						if (ctr !== chk) {
 							ctr = chk;
 							if (helper.is(':visible') && helper.data('dropover') && ! helper.data('droped')) {
-								helper.toggleClass('elfinder-drag-helper-plus', helper.data('locked')? true : ctr);
+								if (self.options.enableDragCopy) {
+									helper.toggleClass('elfinder-drag-helper-plus', helper.data('locked')? true : ctr);
+								}
 								self.trigger(ctr? 'unlockfiles' : 'lockfiles', {files : hashes, helper: helper});
 							}
 						}

--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -1608,7 +1608,7 @@ var elFinder = function(elm, opts, bootCallback) {
 				result  = [],
 				dups    = [],
 				faults  = [],
-				isCopy  = ui.helper.hasClass('elfinder-drag-helper-plus'),
+				isCopy  = ui.helper.hasClass('elfinder-drag-helper-plus') && self._commands['copy'],
 				c       = 'class',
 				cnt, hash, i, h;
 			

--- a/js/elFinder.options.js
+++ b/js/elFinder.options.js
@@ -1345,5 +1345,13 @@ elFinder.prototype._options = {
 	 *
 	 * @type Boolean|Object (toast options)
 	 */
-	toastBackendWarn : true
+	toastBackendWarn : true,
+
+	/**
+	 * Allow keyboard modifiers for copy when dragging
+	 *
+	 * @type Boolean
+	 * @default true
+	 */
+	enableDragCopy : true
 };

--- a/js/ui/cwd.js
+++ b/js/ui/cwd.js
@@ -1158,7 +1158,7 @@ $.fn.elfindercwd = function(fm, options) {
 						status = 'elfinder-drag-helper-plus';
 					} else {
 						status = 'elfinder-drag-helper-move';
-						if (ctr) {
+						if (ctr && fm.options.enableDragCopy) {
 							status += ' elfinder-drag-helper-plus';
 						}
 					}

--- a/js/ui/cwd.js
+++ b/js/ui/cwd.js
@@ -1949,7 +1949,8 @@ $.fn.elfindercwd = function(fm, options) {
 
 					if (!mobile && !$this.data('dragRegisted') && !$this.hasClass(clTmp) && !$this.hasClass(clDraggable) && !$this.hasClass(clDisabled)) {
 						$this.data('dragRegisted', true);
-						if (!fm.isCommandEnabled('copy', fm.searchStatus.state > 1 || $this.hasClass('isroot')? fm.cwdId2Hash($this.attr('id')) : void 0)) {
+						if (!fm.isCommandEnabled('copy', fm.searchStatus.state > 1 || $this.hasClass('isroot')? fm.cwdId2Hash($this.attr('id')) : void 0) &&
+			                            !fm.isCommandEnabled('cut', fm.searchStatus.state > 1 || $this.hasClass('isroot')? fm.cwdId2Hash($this.attr('id')) : void 0)) {
 							return;
 						}
 						$this.on('mousedown', function(e) {

--- a/js/ui/tree.js
+++ b/js/ui/tree.js
@@ -324,7 +324,7 @@ $.fn.elfindertree = function(fm, opts) {
 						status = 'elfinder-drag-helper-plus';
 					} else {
 						status = 'elfinder-drag-helper-move';
-						if (e.shiftKey || e.ctrlKey || e.metaKey) {
+						if ((e.shiftKey || e.ctrlKey || e.metaKey) && fm.options.enableDragCopy) {
 							status += ' elfinder-drag-helper-plus';
 						}
 					}


### PR DESCRIPTION
I had an issue where dragging wasn't enabled when copy command was removed but cut command was still active.

```JS
bootCallback: function (fm) {
    delete fm.commands.copy;
}
```

This change now allows dragging when only cut is active.  I still have a problem when either `shiftKey` or `ctrlKey` modifier is used to allow copy.  I commented out the line below as a workaround, is there a way to check to see if copy command is enabled?

https://github.com/Studio-42/elFinder/blob/33eea861cb07196edbde5d9188f65a6ce81be21f/js/elFinder.js#L5185

Or maybe a [uiOptions](https://github.com/Studio-42/elFinder/wiki/Client-configuration-options-2.1#uiOptions) similar to metakeyDragout for `cwd`?