### PR TITLE
Add cwd param to proc_open

### DIFF
--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -5105,12 +5105,13 @@ var go = function() {
      * @param  string $output       stdout strings
      * @param  int    $return_var   process exit code
      * @param  string $error_output stderr strings
+     * @param  null   $cwd          cwd
      *
      * @return int exit code
      * @throws elFinderAbortException
      * @author Alexey Sukhotin
      */
-    public static function procExec($command, &$output = '', &$return_var = -1, &$error_output = '')
+    public static function procExec($command, &$output = '', &$return_var = -1, &$error_output = '', $cwd = null)
     {
 
         static $allowed = null;
@@ -5140,7 +5141,7 @@ var go = function() {
             2 => array("pipe", "w")   // stderr
         );
 
-        $process = proc_open($command, $descriptorspec, $pipes, null, null);
+        $process = proc_open($command, $descriptorspec, $pipes, $cwd, null);
 
         if (is_resource($process)) {
             stream_set_blocking($pipes[1], 0);

--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -6353,7 +6353,7 @@ abstract class elFinderVolumeDriver
      * @throws elFinderAbortException
      * @author Alexey Sukhotin
      */
-    protected function procExec($command, &$output = '', &$return_var = -1, &$error_output = '')
+    protected function procExec($command, &$output = '', &$return_var = -1, &$error_output = '', $cwd = null)
     {
         return elFinder::procExec($command, $output, $return_var, $error_output);
     }
@@ -6860,7 +6860,8 @@ abstract class elFinderVolumeDriver
                 $files = array_map('escapeshellarg', $files);
 
                 $cmd = $arc['cmd'] . ' ' . $arc['argc'] . ' ' . escapeshellarg($name) . ' ' . implode(' ', $files);
-                $this->procExec($cmd, $o, $c);
+                $err_out = '';
+                $this->procExec($cmd, $o, $c, $err_out, $dir);
                 chdir($cwd);
             } else {
                 return false;


### PR DESCRIPTION
The create archive feature does not work on php's that are compiled with thread safety.

That's because chdir() used in the elFinderVolumeDriver::makeArchive() function
does not change the current directory for the OS, see: https://www.php.net/manual/en/function.chdir.php#refsect1-function.chdir-notes

In order to fix that, the procExec() function can be made to accept an additional
parameter for the $cwd which then can be passed to proc_open(). 