### PR TITLE
[ui:cwd] make easily able to mapping mimetype to the kind

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -8937,6 +8937,11 @@ elFinder.prototype = {
 			} else {
 				kind = this.kinds[mime];
 			}
+		} else if (this.mimeTypes[mime]) {
+			kind = this.mimeTypes[mime].toUpperCase();
+			if (!this.messages['kind'+kind]) {
+				kind = null;
+			}
 		}
 		if (! kind) {
 			if (mime.indexOf('text') === 0) {


### PR DESCRIPTION
`"kind"+ FILE EXTENSION` By defining a language member, you can easily add the file type displayed in the UI.

ref. #3369

It can be...

from

```javascript
fm.bind('init', function() {
    fm.kinds['image/vnd.dxf'] = 'DXF';
    fm.messages['kindDXF'] = 'AutoCAD DXF';
});
```

to

```javascript
fm.bind('init', function() {
    fm.messages['kindDXF'] = 'AutoCAD DXF';
});