### PR TITLE
Correctly urlencode path in setcookie(); fix #3538

### DIFF
--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -2082,7 +2082,7 @@ class elFinder
         }
 
         if ($args['cpath'] && $args['reqid']) {
-            setcookie('elfdl' . $args['reqid'], '1', 0, $args['cpath']);
+            setcookie('elfdl' . $args['reqid'], '1', 0, urlencode($args['cpath']));
         }
 
         $result = array(


### PR DESCRIPTION
Some characters are valid in URLs but not in cookies, eg. comma or semicolon.
They needs to be encoded properly.