### PR TITLE
elFinder.js: Fix multiple calls to elFinder.sync() method when dispat…

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -4821,7 +4821,7 @@ var elFinder = function(elm, opts, bootCallback) {
 		});
 
 		// bind window onmessage for CORS
-		$(window).on('message.' + namespace, function(e){
+		$(window).on('message.' + namespace, function(e) {
 			var res = e.originalEvent || null,
 				obj, data;
 			if (res && (self.convAbsUrl(self.options.url).indexOf(res.origin) === 0 || self.convAbsUrl(self.uploadURL).indexOf(res.origin) === 0)) {
@@ -4848,7 +4848,20 @@ var elFinder = function(elm, opts, bootCallback) {
 						}
 					}
 				} catch (e) {
-					self.sync();
+					try {
+						// Execute only if there is no _syncLocker variable
+						if(self._syncLocker === undefined) {
+							// Create a lock to avoid multiple executions of the sync() method
+							self._syncLocker = true;
+							// Sync and ...
+							self.sync().finally(function() {
+								// .. release lock
+								delete self._syncLocker;
+							});
+						}
+					} catch(ex) {
+						// console.error({ex});
+					}
 				}
 			}
 		});


### PR DESCRIPTION
If the user has browser extensions installed that send a Message then this message is intercepted by js/elFinder.js:4827, and since the message is not a string of type JSON an exception is returned and the self.sync() method is called.
Using the example of the [wappalyzer](https://www.wappalyzer.com/) add-on - a dozen notifications are sent at once by which elFinder sends multiple requests at once to the application backend.

Here is an example for 32 queries through the wappalyzer add-on:
![image](https://github.com/Studio-42/elFinder/assets/7090340/c385a794-1902-482d-ac04-df735724db51)
