### PR TITLE
Used switch statement instead of if-else

### DIFF
--- a/js/worker/quicklook.unzip.js
+++ b/js/worker/quicklook.unzip.js
@@ -44,12 +44,22 @@ var type = self.data.type,
 	};
 
 self.res = {};
-if (type === 'tar') {
-	self.res.files = tarFiles(new Uint8Array(bin));
-} else if (type === 'zip') {
-	self.res.files = unzipFiles.call(new Zlib.Unzip(new Uint8Array(bin)));
-} else if (type === 'gzip') {
-	self.res.files = tarFiles((new Zlib.Gunzip(new Uint8Array(bin))).decompress());
-} else if (type === 'bzip2') {
-	self.res.files = tarFiles(self.bzip2.simple(self.bzip2.array(new Uint8Array(bin))));
+
+switch (type) {
+  case 'tar':
+    self.res.files = tarFiles(bin);
+    break;
+  case 'zip':
+    self.res.files = unzipFiles.call(new Zlib.Unzip(bin));
+    break;
+  case 'gzip':
+    self.res.files = tarFiles(new Zlib.Gunzip(bin).decompress());
+    break;
+  case 'bzip2':
+    self.res.files = tarFiles(self.bzip2.simple(self.bzip2.array(bin)));
+    break;
+  default:
+    
+    break;
 }
+


### PR DESCRIPTION
Using a switch statement makes the code more readable and easier to manage when dealing with different cases based on the type.