### PR TITLE
Fixed elfinder.src.html in README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Installation
       ```
 
  2. Rename `/php/connector.minimal.php-dist` to `/php/connector.minimal.php`
- 3. Load `/elfinder.src.html` in your browser to run elFinder
+ 3. Load `/elfinder.html` in your browser to run elFinder
 
 ### Installer
  - [Setup elFinder 2.1.x nightly with Composer](https://github.com/Studio-42/elFinder/tree/gh-pages/tools/installer/setup_with_composer)


### PR DESCRIPTION
I see that the file is actually elfinder.html and that it's correctly referenced in the wiki