### PR TITLE
[PHP 8.4] Fix: Curl `CURLOPT_BINARYTRANSFER` deprecated

### DIFF
--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -2706,7 +2706,6 @@ class elFinder
             curl_setopt($ch, CURLOPT_FILE, $outfp);
         } else {
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-            curl_setopt($ch, CURLOPT_BINARYTRANSFER, true);
         }
         curl_setopt($ch, CURLOPT_LOW_SPEED_LIMIT, 1);
         curl_setopt($ch, CURLOPT_LOW_SPEED_TIME, $timeout);


### PR DESCRIPTION
The `CURLOPT_BINARYTRANSFER` PHP constant from the Curl extension was no-op since PHP 5.1, and is deprecated in PHP 8.4. This removes the constant usage to avoid the deprecation notice in PHP 8.4 and later.

Because this constant was no-op since PHP 5.1 (circa 2005), this change has no impact.

See:

 - [PHP.Watch - PHP 8.4 - Curl: CURLOPT_BINARYTRANSFER deprecated](https://php.watch/versions/8.4/CURLOPT_BINARYTRANSFER-deprecated)
 - [commit](https://github.com/php/php-src/commit/fc16285538e96ecb35d017231051f83dcbd8b55b)