### PR TITLE
try copy / deleting folder if moving it doesn't work

### DIFF
--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -5329,7 +5329,16 @@ abstract class elFinderVolumeDriver
         $this->rmTmb($stat); // can not do rmTmb() after _move()
         $this->clearcache();
 
-        if ($res = $this->convEncOut($this->_move($this->convEncIn($src), $this->convEncIn($dst), $this->convEncIn($name)))) {
+        $res = $this->convEncOut($this->_move($this->convEncIn($src), $this->convEncIn($dst), $this->convEncIn($name)));
+        // if moving it didn't work try to copy / delete
+        if (!$res) {
+            $res = $this->copy($src, $dst, $name);
+            if (!$this->remove($src)) {
+                $res = false;
+            }
+        }
+
+        if ($res) {
             $this->clearstatcache();
             if ($stat['mime'] === 'directory') {
                 $this->updateSubdirsCache($dst, true);


### PR DESCRIPTION
When folders are being copied elFinder creates the destination folder and then iterates through the source folder copying, individually, all the files contained within.

When folders are being moved, however, elFinder just tries to move the destination folder to the source folder and that's that.

Altho some underlying drivers may support that not all do. This PR makes it so that if moving a folder fails it tries to copy the source folder to the destination folder and then it tries to delete the source folder.

This provides a workaround for #3649