### PR TITLE
Allow image URL in theme manifest.json to be a relative link as well

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -10235,6 +10235,9 @@ elFinder.prototype = {
 						if (themeObj.cssurls) {
 							themeObj.cssurls = absUrl(themeObj.cssurls, m[1]);
 						}
+						if (themeObj.image) {
+							themeObj.image = absUrl(themeObj.image, m[1]);
+						}
 						dfd.resolve(themeObj);
 					}).fail(function() {
 						dfd.reject();


### PR DESCRIPTION
Relative links are resolved against the manifest.json, the same way as is done for the CSS URL.

This is needed when you are living places of the world where you need to host everything yourself, as linking to external servers is difficult due to privacy concerns. If your software can be hosted on different servers, everything needs to be relative to work properly.