### PR TITLE
Fixes #3684

### DIFF
--- a/js/commands/resize.js
+++ b/js/commands/resize.js
@@ -207,35 +207,7 @@ elFinder.prototype.commands.resize = function() {
 						'<input class="api2" type="radio" name="type" id="'+id+'-crop" value="crop" /><label class="api2" for="'+id+'-crop">'+fm.i18n('crop')+'</label>',
 						'<input class="api2" type="radio" name="type" id="'+id+'-rotate" value="rotate" /><label class="api2" for="'+id+'-rotate">'+fm.i18n('rotate')+'</label>'),
 					mode     = 'resize',
-					type     = uitype[ctrgrup]()[ctrgrup]('disable').find('input')
-						.on('change', function() {
-							mode = $(this).val();
-							
-							resetView();
-							resizable(true);
-							croppable(true);
-							rotateable(true);
-							
-							if (mode == 'resize') {
-								uiresize.show();
-								uirotate.hide();
-								uicrop.hide();
-								resizable();
-								isJpeg && grid8px.insertAfter(uiresize.find('.elfinder-resize-grid8'));
-							}
-							else if (mode == 'crop') {
-								uirotate.hide();
-								uiresize.hide();
-								uicrop.show();
-								croppable();
-								isJpeg && grid8px.insertAfter(uicrop.find('.elfinder-resize-grid8'));
-							} else if (mode == 'rotate') {
-								uiresize.hide();
-								uicrop.hide();
-								uirotate.show();
-								rotateable();
-							}
-						}),
+					type     = uitype.find('input'),
 					width   = $(input)
 						.on('change', function() {
 							var w = round(parseInt(width.val())),
@@ -1484,7 +1456,37 @@ elFinder.prototype.commands.resize = function() {
 						}
 					}
 				}).attr('id', id).closest('.ui-dialog').addClass(clsediting);
-				
+
+				// Fix for https://github.com/Studio-42/elFinder/issues/3684
+				uitype[ctrgrup]()[ctrgrup]('disable').find('input')
+					.on('change', function() {
+						mode = $(this).val();
+						
+						resetView();
+						resizable(true);
+						croppable(true);
+						rotateable(true);
+						
+						if (mode == 'resize') {
+							uiresize.show();
+							uirotate.hide();
+							uicrop.hide();
+							resizable();
+							isJpeg && grid8px.insertAfter(uiresize.find('.elfinder-resize-grid8'));
+						}
+						else if (mode == 'crop') {
+							uirotate.hide();
+							uiresize.hide();
+							uicrop.show();
+							croppable();
+							isJpeg && grid8px.insertAfter(uicrop.find('.elfinder-resize-grid8'));
+						} else if (mode == 'rotate') {
+							uiresize.hide();
+							uicrop.hide();
+							uirotate.show();
+							rotateable();
+						}
+					})
 				// for IE < 9 dialog mising at open second+ time.
 				if (fm.UA.ltIE8) {
 					$('.elfinder-dialog').css('filter', '');


### PR DESCRIPTION
See #3684 for details. JQueryUI's checkboxradio widget must be initialized only after the element was added to the DOM.