### PR TITLE
Fixes #3432, check if posted message was intended for elfinder

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -4838,8 +4838,18 @@ var elFinder = function(elm, opts, bootCallback) {
 				obj, data;
 			if (res && (self.convAbsUrl(self.options.url).indexOf(res.origin) === 0 || self.convAbsUrl(self.uploadURL).indexOf(res.origin) === 0)) {
 				try {
-					obj = JSON.parse(res.data);
-					data = obj.data || null;
+					try {
+						if (typeof res.data !== 'string') {
+							return;
+						}
+						obj = JSON.parse(res.data);
+						if (obj.type !== "io.studio-42.github") {
+							return;
+						}
+						data = obj.data || null;
+					} catch (e2) {
+						return;
+					} 
 					if (data) {
 						if (data.error) {
 							if (obj.bind) {

--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -4183,7 +4183,7 @@ var go = function() {
         }
     } catch(e) {
         // for CORS
-        w.postMessage && w.postMessage(JSON.stringify({bind:\'' . $bind . '\',data:' . $json . '}), \'' . $origin . '\');
+        w.postMessage && w.postMessage(JSON.stringify({type:\'io.studio-42.github\',bind:\'' . $bind . '\',data:' . $json . '}), \'' . $origin . '\');
     }
     close();
     setTimeout(function() {


### PR DESCRIPTION
Fixes #3432, check if posted message was intended for elfinder; and ignore posted messages that are not intended for ElFinder. This way, elfinder does not try to react to messages posted by other libraries and code, which can lead to various issues.  For example, we are using [monaco editor](https://microsoft.github.io/monaco-editor/) as a code editor for files in ElFinder and monaco editor also uses `postMessage`.