### PR TITLE
Implements #3697, ask before closing edit dialog on unsaved changes

### DIFF
--- a/js/i18n/elfinder.LANG.js
+++ b/js/i18n/elfinder.LANG.js
@@ -181,6 +181,7 @@
 			'btnCancel' : 'Cancel',
 			'btnNo'     : 'No',
 			'btnYes'    : 'Yes',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Mount',  // added 18.04.2012
 			'btnApprove': 'Goto $1 & approve', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Unmount', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.ar.js
+++ b/js/i18n/elfinder.ar.js
@@ -175,6 +175,7 @@
 			'btnCancel' : 'إلغاء',
 			'btnNo'     : 'لا',
 			'btnYes'    : 'نعم',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'تثبيت',  // added 18.04.2012
 			'btnApprove': 'انتقل إلى $1 والموافقة', // from v2.1 added 26.04.2012
 			'btnUnmount': 'إلغاء التثبيت', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.bg.js
+++ b/js/i18n/elfinder.bg.js
@@ -173,6 +173,7 @@
 			'btnCancel' : 'Отказ',
 			'btnNo'     : 'Не',
 			'btnYes'    : 'Да',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Монтирай',  // added 18.04.2012
 			'btnApprove': 'Отиди на $1 и одобри', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Размонтирай', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.ca.js
+++ b/js/i18n/elfinder.ca.js
@@ -138,6 +138,7 @@
 			'btnCancel' : 'Cancel·la',
 			'btnNo'     : 'No',
 			'btnYes'    : 'Sí',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Mount',
 			
 			/******************************** notifications ********************************/

--- a/js/i18n/elfinder.cs.js
+++ b/js/i18n/elfinder.cs.js
@@ -175,6 +175,7 @@
 			'btnCancel' : 'Zrušit',
 			'btnNo'     : 'Ne',
 			'btnYes'    : 'Ano',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Připojit',  // added 18.04.2012
 			'btnApprove': 'Přejít do části 1 $ & schválit', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Odpojit', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.da.js
+++ b/js/i18n/elfinder.da.js
@@ -174,6 +174,7 @@
 			'btnCancel' : 'Annuler',
 			'btnNo'     : 'Nej',
 			'btnYes'    : 'Ja',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Mount',  // added 18.04.2012
 			'btnApprove': 'Gå til $1 & godkend', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Unmount', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.de.js
+++ b/js/i18n/elfinder.de.js
@@ -178,6 +178,7 @@
 			'btnCancel' : 'Abbrechen',
 			'btnNo'     : 'Nein',
 			'btnYes'    : 'Ja',
+			'btnDiscard': 'Änderungen verwerfen',
 			'btnMount'  : 'Verbinden',  // added 18.04.2012
 			'btnApprove': 'Gehe zu $1 und genehmige', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Auswerfen', // from v2.1 added 30.04.2012
@@ -305,7 +306,7 @@
 			'confirmRest'     : 'Vorhandenes Element durch das Element aus Mülleimer ersetzen?', // fromv2.1.24 added 5.5.2017
 			'confirmConvUTF8' : 'Nicht UTF-8 kodiert<br>Zu UTF-8 konvertieren?<br>Inhalte werden zu UTF-8 konvertiert bei Speicherung.', // from v2.1 added 08.04.2014
 			'confirmNonUTF8'  : 'Die Zeichencodierung dieser Datei konnte nicht erkannt werden. Es muss vorübergehend in UTF-8 zur Bearbeitung konvertiert werden.<br> Bitte eine Zeichenkodierung dieser Datei auswählen.', // from v2.1.19 added 28.11.2016
-			'confirmNotSave'  : 'Die Datei wurde geändert.<br>Änderungen gehen verloren wenn nicht gespeichert wird.', // from v2.1 added 15.7.2015
+			'confirmNotSave'  : 'Die Datei wurde geändert.<br>Änderungen gehen verloren, wenn nicht gespeichert wird.', // from v2.1 added 15.7.2015
 			'confirmTrash'    : 'Sicher diese Elemente in den Mülleimer verschieben?', // from v2.1.24 added 29.4.2017
 			'confirmMove'     : 'Sicher alle Elemente nach "$1" verschieben?', // from v2.1.50 added 13.12.2019
 			'apllyAll'        : 'Alles bestätigen',

--- a/js/i18n/elfinder.el.js
+++ b/js/i18n/elfinder.el.js
@@ -138,6 +138,7 @@
 			'btnCancel' : 'Ακύρωση',
 			'btnNo'     : 'Όχι',
 			'btnYes'    : 'Ναι',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Mount',
 			
 			/******************************** notifications ********************************/

--- a/js/i18n/elfinder.en.js
+++ b/js/i18n/elfinder.en.js
@@ -168,6 +168,7 @@ if (typeof elFinder === 'function' && elFinder.prototype.i18) {
 			'btnCancel' : 'Cancel',
 			'btnNo'     : 'No',
 			'btnYes'    : 'Yes',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Mount',  // added 18.04.2012
 			'btnApprove': 'Goto $1 & approve', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Unmount', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.es.js
+++ b/js/i18n/elfinder.es.js
@@ -174,6 +174,7 @@
 			'btnCancel' : 'Cancelar',
 			'btnNo'     : 'No',
 			'btnYes'    : 'Sí',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Montar',  // added 18.04.2012
 			'btnApprove': 'Ir a $1 y aprobar', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Desmontar', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.fa.js
+++ b/js/i18n/elfinder.fa.js
@@ -174,6 +174,7 @@
 			'btnCancel' : 'انصراف',
 			'btnNo'     : 'خیر',
 			'btnYes'    : 'بلی',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'اتصال',  // added 18.04.2012
 			'btnApprove': 'رفتن به $1 و تایید', // from v2.1 added 26.04.2012
 			'btnUnmount': 'قطع اتصال', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.fo.js
+++ b/js/i18n/elfinder.fo.js
@@ -146,6 +146,7 @@
 			'btnCancel' : 'Angra',
 			'btnNo'     : 'Nei',
 			'btnYes'    : 'Ja',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Mount',  // added 18.04.2012
 			'btnApprove': 'Goto $1 & approve', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Unmount', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.fr.js
+++ b/js/i18n/elfinder.fr.js
@@ -176,6 +176,7 @@
 			'btnCancel' : 'Annuler',
 			'btnNo'     : 'Non',
 			'btnYes'    : 'Oui',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Monter',  // added 18.04.2012
 			'btnApprove': 'Aller à $1 & approuver', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Démonter', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.fr_CA.js
+++ b/js/i18n/elfinder.fr_CA.js
@@ -175,6 +175,7 @@
 			'btnCancel' : 'Annuler',
 			'btnNo'     : 'Non',
 			'btnYes'    : 'Oui',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Monter',  // added 18.04.2012
 			'btnApprove': 'Aller à $1 & approuver', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Démonter', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.he.js
+++ b/js/i18n/elfinder.he.js
@@ -138,6 +138,7 @@
 			'btnCancel' : 'ביטול',
 			'btnNo'     : 'לא',
 			'btnYes'    : 'כן',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'עיגון',  // added 18.04.2012
 
 			/******************************** notifications ********************************/

--- a/js/i18n/elfinder.hr.js
+++ b/js/i18n/elfinder.hr.js
@@ -149,6 +149,7 @@
 			'btnCancel' : 'Odustani',
 			'btnNo'     : 'Ne',
 			'btnYes'    : 'Da',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Mount',  // added 18.04.2012
 			'btnApprove': 'Goto $1 & approve', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Unmount', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.hu.js
+++ b/js/i18n/elfinder.hu.js
@@ -174,6 +174,7 @@
 			'btnCancel' : 'Mégsem',
 			'btnNo'     : 'Nem',
 			'btnYes'    : 'Igen',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Csatlakoztat',  // added 18.04.2012
 			'btnApprove': 'Tovább $1 és jóváhagyás', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Leválaszt', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.id.js
+++ b/js/i18n/elfinder.id.js
@@ -162,6 +162,7 @@
 			'btnCancel' : 'Batal',
 			'btnNo'     : 'Tidak',
 			'btnYes'    : 'Ya',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Baca susunan',  // added 18.04.2012
 			'btnApprove': 'Menuju ke $1 & setujui', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Unmount', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.it.js
+++ b/js/i18n/elfinder.it.js
@@ -178,6 +178,7 @@
 			'btnCancel' : 'Annulla',
 			'btnNo'     : 'No',
 			'btnYes'    : 'Sì',
+			'btnDiscard': 'Scartare le modifiche',
 			'btnMount'  : 'Monta',  // added 18.04.2012
 			'btnApprove': 'Vai a $1 & approva', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Smonta', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.ja.js
+++ b/js/i18n/elfinder.ja.js
@@ -175,6 +175,7 @@
 			'btnCancel' : 'キャンセル',
 			'btnNo'     : 'いいえ',
 			'btnYes'    : 'はい',
+			'btnDiscard': '変更を破棄',
 			'btnMount'  : 'マウント',  // added 18.04.2012
 			'btnApprove': '$1へ行き認可する', // from v2.1 added 26.04.2012
 			'btnUnmount': 'アンマウント', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.ko.js
+++ b/js/i18n/elfinder.ko.js
@@ -177,6 +177,7 @@
 			'btnCancel' : '취소',
 			'btnNo'     : '아니오',
 			'btnYes'    : '예',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : '마운트',  // added 18.04.2012
 			'btnApprove': '$1로 이동 및 승인', // from v2.1 added 26.04.2012
 			'btnUnmount': '마운트 해제', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.nl.js
+++ b/js/i18n/elfinder.nl.js
@@ -163,7 +163,7 @@
 			'cmdselectinvert'      : 'Selectie omkeren', // from v2.1.28 added 15.08.2017
 			'cmdopennew'           : 'Open in nieuw venster', // from v2.1.38 added 3.4.2018
 			'cmdhide'              : 'Verberg (voorkeur)', // from v2.1.41 added 24.7.2018
-
+ 
 
 			/*********************************** buttons ***********************************/
 			'btnClose'             : 'Sluit',
@@ -173,6 +173,7 @@
 			'btnCancel'            : 'Annuleren',
 			'btnNo'                : 'Nee',
 			'btnYes'               : 'Ja',
+			'btnDiscard'           : 'Wijzigingen weggooien',
 			'btnMount'             : 'Mount',  // added 18.04.2012
 			'btnApprove'           : 'Ga naar $1 & keur goed', // from v2.1 added 26.04.2012
 			'btnUnmount'           : 'Unmount', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.no.js
+++ b/js/i18n/elfinder.no.js
@@ -138,6 +138,7 @@
 			'btnCancel' : 'Avbryt',
 			'btnNo'     : 'Nei',
 			'btnYes'    : 'Ja',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Mount',
 			
 			/******************************** notifications ********************************/

--- a/js/i18n/elfinder.pl.js
+++ b/js/i18n/elfinder.pl.js
@@ -174,6 +174,7 @@
 			'btnCancel' : 'Anuluj',
 			'btnNo'     : 'Nie',
 			'btnYes'    : 'Tak',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Montuj',  // added 18.04.2012
 			'btnApprove': 'Idź do $1 & zatwierdź', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Odmontuj', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.pt_BR.js
+++ b/js/i18n/elfinder.pt_BR.js
@@ -176,6 +176,7 @@
 			'btnCancel' : 'Cancelar',
 			'btnNo'     : 'Não',
 			'btnYes'    : 'Sim',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Montar',  // added 18.04.2012
 			'btnApprove': 'Vá para $1 & aprove', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Desmontar', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.ro.js
+++ b/js/i18n/elfinder.ro.js
@@ -146,6 +146,7 @@
 			'btnCancel' : 'Anulează',
 			'btnNo'     : 'Nu',
 			'btnYes'    : 'Da',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Încarcă',  // added 18.04.2012
 			'btnApprove': 'Mergi la $1 și aprobă', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Elimină volum', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.ru.js
+++ b/js/i18n/elfinder.ru.js
@@ -177,6 +177,7 @@
 			'btnCancel' : 'Отмена',
 			'btnNo'     : 'Нет',
 			'btnYes'    : 'Да',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Подключить',  // added 18.04.2012
 			'btnApprove': 'Перейти в $1 и применить', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Отключить', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.si.js
+++ b/js/i18n/elfinder.si.js
@@ -170,6 +170,7 @@
 			'btnCancel' : 'අවලංගු කරන්න',
 			'btnNo'     : 'නැත',
 			'btnYes'    : 'ඔව්',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'සවිකිරීම(Mount)',  // added 18.04.2012
 			'btnApprove': 'කරුණාකර $1 අනුමත කරන්න', // from v2.1 added 26.04.2012
 			'btnUnmount': 'ගලවන්න(Unmount)', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.sk.js
+++ b/js/i18n/elfinder.sk.js
@@ -175,6 +175,7 @@
 			'btnCancel' : 'Zrušiť',
 			'btnNo'     : 'Nie',
 			'btnYes'    : 'Áno',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Pripojiť',  // added 18.04.2012
 			'btnApprove': 'Ísť na $1 & schváliť', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Odpojiť', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.sl.js
+++ b/js/i18n/elfinder.sl.js
@@ -138,6 +138,7 @@
 			'btnCancel' : 'Prekliči',
 			'btnNo'     : 'Ne',
 			'btnYes'    : 'Da',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Mount',
 			
 			/******************************** notifications ********************************/

--- a/js/i18n/elfinder.sr.js
+++ b/js/i18n/elfinder.sr.js
@@ -138,6 +138,7 @@
 			'btnCancel' : 'Prekini',
 			'btnNo'     : 'Ne',
 			'btnYes'    : 'Da',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Mount',
 			
 			/******************************** notifications ********************************/

--- a/js/i18n/elfinder.sv.js
+++ b/js/i18n/elfinder.sv.js
@@ -138,6 +138,7 @@
 			'btnCancel' : 'Ångra',
 			'btnNo'     : 'Nej',
 			'btnYes'    : 'Ja',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Mount',
 			
 			/******************************** notifications ********************************/

--- a/js/i18n/elfinder.tr.js
+++ b/js/i18n/elfinder.tr.js
@@ -178,6 +178,7 @@
 			'btnCancel' : 'İptal',
 			'btnNo'     : 'Hayır',
 			'btnYes'    : 'Evet',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Bağla',  // added 18.04.2012
 			'btnApprove': 'Git $1 & onayla', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Bağlantıyı kes', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.ug_CN.js
+++ b/js/i18n/elfinder.ug_CN.js
@@ -138,6 +138,7 @@
 			'btnCancel' : 'بېكارلاش',
 			'btnNo'     : 'ياق',
 			'btnYes'    : 'ھەئە',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'يۈكلەش',  // added 18.04.2012
 
 			/******************************** notifications ********************************/

--- a/js/i18n/elfinder.uk.js
+++ b/js/i18n/elfinder.uk.js
@@ -174,6 +174,7 @@
 			'btnCancel' : 'Скасувати',
 			'btnNo'     : 'Ні',
 			'btnYes'    : 'Так',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Підключити',  // added 18.04.2012
 			'btnApprove': 'Перейти в $1 і прийняти', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Відключити', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.vi.js
+++ b/js/i18n/elfinder.vi.js
@@ -175,6 +175,7 @@
 			'btnCancel' : 'Hủy bỏ',
 			'btnNo'     : 'Không',
 			'btnYes'    : 'Đồng ý',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : 'Mount',  // added 18.04.2012
 			'btnApprove': 'Goto $1 & approve', // from v2.1 added 26.04.2012
 			'btnUnmount': 'Unmount', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.zh_CN.js
+++ b/js/i18n/elfinder.zh_CN.js
@@ -179,6 +179,7 @@
 			'btnCancel' : '取消',
 			'btnNo'     : '否',
 			'btnYes'    : '是',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : '装载',  // added 18.04.2012
 			'btnApprove': '至 $1 并确认', // from v2.1 added 26.04.2012
 			'btnUnmount': '卸载', // from v2.1 added 30.04.2012

--- a/js/i18n/elfinder.zh_TW.js
+++ b/js/i18n/elfinder.zh_TW.js
@@ -179,6 +179,7 @@
 			'btnCancel' : '取消',
 			'btnNo'     : '否',
 			'btnYes'    : '是',
+			'btnDiscard': 'Discard changes',
 			'btnMount'  : '掛接',  // added 18.04.2012
 			'btnApprove': '前往 $1 並核准', // from v2.1 added 26.04.2012
 			'btnUnmount': '卸載', // from v2.1 added 30.04.2012

--- a/js/ui/dialog.js
+++ b/js/ui/dialog.js
@@ -194,6 +194,10 @@ $.fn.elfinderdialog = function(opts, fm) {
 						.on('mousedown touchstart', function(e) {
 							e.preventDefault();
 							e.stopPropagation();
+							if (typeof opts.headerBtnCloseAction === 'function') {
+								opts.headerBtnCloseAction(e);
+								return;
+							}
 							self.elfinderdialog('close');
 						})
 					);
@@ -804,6 +808,7 @@ $.fn.elfinderdialog.defaults = {
 	openMaximized : false,
 	headerBtnPos : 'auto',
 	headerBtnOrder : 'auto',
+	headerBtnCloseAction: null,
 	optimizeNumber : true,
 	propagationEvents : ['mousemove', 'mouseup']
 };


### PR DESCRIPTION
Adds a new option `commandsOptions.edit.confirmUnsavedBeforeClose`.

Defaults to `false`. When `set` to true, the edit dialog asks the user for confirmation first when they have unsaved changes and attempt to close the dialog. The user can either cancel the operation, keeping the dialog open, discard their changes, or save their changes.

Implements #3697