### PR TITLE
Fix build for Windows environment

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -414,7 +414,7 @@ task('js/extras', function(){
 	var files = grep(path.join(src, 'js', 'extras'), '\\.js$');
 	var base, name, result;
 	for (var i in files) {
-		name = files[i].replace(/^.+\/([^\/]+)$/, '$1');
+		name = files[i].replace(/\\/g, "/").replace(/^.+\/([^\/]+)$/, '$1');
 		if (! name.match(/\.min\./)) {
 			base = name.replace(/\.js$/, '');
 			name = 'js/extras/' + name;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "File manager for web",
   "main": "Jakefile.js",
   "scripts": {
-    "build": "mkdir -p ./build && jake -C ./build elfinder"
+    "build": "mkdir ./build && jake -C ./build elfinder"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fix build for Windows environment

`mkdir` command in Windows does not have a `-p` option. Creating the parents seems unnecessary, as the parent folder is the project root and that should always exist. So I simply removed the `-p` option.

Windows uses backslashes (`\`) as the path separator. I replaced backslashes with forward slashes (`/`) to normalize the paths.