### PR TITLE
Replace usage of deprecated `E_STRICT` constant

### DIFF
--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -606,9 +606,13 @@ class elFinder
         $this->version = (string)self::$ApiVersion;
 
         // set error handler of WARNING, NOTICE
-        $errLevel = E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE | E_STRICT | E_RECOVERABLE_ERROR;
+        $errLevel = E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE | E_RECOVERABLE_ERROR;
         if (defined('E_DEPRECATED')) {
             $errLevel |= E_DEPRECATED | E_USER_DEPRECATED;
+        }
+        // E_STRICT is deprecated; see https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant
+        if (defined('E_STRICT')) {
+            $errLevel |= @E_STRICT;
         }
         set_error_handler('elFinder::phpErrorHandler', $errLevel);
 
@@ -4287,17 +4291,18 @@ var go = function() {
                 $proc = true;
                 break;
 
-            case E_STRICT:
-                elFinder::$phpErrors[] = "STRICT: $errstr in $errfile line $errline.";
-                $proc = true;
-                break;
-
             case E_RECOVERABLE_ERROR:
                 elFinder::$phpErrors[] = "RECOVERABLE_ERROR: $errstr in $errfile line $errline.";
                 $proc = true;
                 break;
         }
 
+        // E_STRICT is deprecated; see https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant
+        if (defined('E_STRICT') && $errno === @E_STRICT) {
+            elFinder::$phpErrors[] = "STRICT: $errstr in $errfile line $errline.";
+            $proc = true;
+        }
+        
         if (defined('E_DEPRECATED')) {
             switch ($errno) {
                 case E_DEPRECATED:

--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -421,9 +421,9 @@ class elFinder
 
     /**
      * LAN class allowed when uploading via URL
-     * 
+     *
      * Array keys are 'local', 'private_a', 'private_b', 'private_c' and 'link'
-     * 
+     *
      * local:     127.0.0.0/8
      * private_a: 10.0.0.0/8
      * private_b: 172.16.0.0/12
@@ -4302,7 +4302,7 @@ var go = function() {
             elFinder::$phpErrors[] = "STRICT: $errstr in $errfile line $errline.";
             $proc = true;
         }
-        
+
         if (defined('E_DEPRECATED')) {
             switch ($errno) {
                 case E_DEPRECATED:
@@ -5230,7 +5230,7 @@ var go = function() {
             $name = str_replace('\\', '/', $name);
         }
         $parts = explode('/', trim($name, '/'));
-        $name = array_pop($parts); 
+        $name = array_pop($parts);
         return $name;
     }
 


### PR DESCRIPTION
The `E_STRICT` constant is deprecated as of PHP 8.4.0 and will be removed in a future version; see also https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant.

This PR replaces the deprecated usage of `E_STRICT` by:
- adding an [error control operator](https://www.php.net/manual/en/language.operators.errorcontrol.php#language.operators.errorcontrol) to usages to silence deprecation warnings
- ensuring a `defined('E_STRICT')` call is issued before trying to access to constant, to ensure compatibility with future PHP versions where this will be removed