### PR TITLE
pressing minimized button ( - ) on the editor while the editor is maximized will close the editor

### DIFF
--- a/js/ui/dialog.js
+++ b/js/ui/dialog.js
@@ -277,7 +277,7 @@ $.fn.elfinderdialog = function(opts, fm) {
 									}).position();
 									mnode = dialog.clone().on('mousedown', function() {
 										$this.trigger('mousedown');
-									}).removeClass('ui-draggable ui-resizable elfinder-frontmost');
+									}).removeClass('ui-draggable ui-resizable elfinder-frontmost elfinder-maximized');
 									tray.append(dum);
 									Object.assign(pos, dum.offset(), dumStyle);
 									dum.remove();


### PR DESCRIPTION
when the editor is minimized from a maximized state it still has the class "elfinder-maximized" which causes it to close, removing the "elfinder-maximized" class on minimize prevents it from closing.

MAXIMIZED:
<img width="1729" height="994" alt="max" src="https://github.com/user-attachments/assets/cf53eeb6-ad8b-4952-9492-7c4654dd3b60" />

MINIMIZED:
<img width="1669" height="956" alt="Screenshot from 2025-10-18 12-51-54" src="https://github.com/user-attachments/assets/d894bab6-ee14-427f-9c54-653b2626eb7f" />