### PR TITLE
Update deprecated php type casts

### DIFF
--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -4394,7 +4394,7 @@ var go = function() {
     protected function utime()
     {
         $time = explode(" ", microtime());
-        return (double)$time[1] + (double)$time[0];
+        return (float)$time[1] + (float)$time[0];
     }
 
     /**


### PR DESCRIPTION
In PHP 8.5, non-canonical scalar type casts (boolean|double|integer|binary) deprecated.

See https://php.watch/versions/8.5/boolean-double-integer-binary-casts-deprecated.