### PR TITLE
Correctly urlencode path in setcookie(); refix Studio-42#3538

### DIFF
--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -2087,7 +2087,7 @@ class elFinder
         }
 
         if ($args['cpath'] && $args['reqid']) {
-            setcookie('elfdl' . $args['reqid'], '1', 0, $args['cpath']);
+            setcookie('elfdl' . $args['reqid'], '1', 0, urlencode($args['cpath']));
         }
 
         $result = array(


### PR DESCRIPTION
Some characters are valid in URLs but not in cookies, eg. comma or semicolon. They needs to be encoded properly.

```
setcookie(): "path" option cannot contain ",", ";", " ", "\t", "\r", "\n", "\013", or "\014" (Error Code: 0)
vendor/studio-42/elfinder/php/elFinder.class.php (2085)
```

This is the same as issue #3538 
It was fixed by #3561 
Then the change was reverted in #3619 
I'm not sure about the problem fixed by #3619, as there's no related issue or explanation on the change.

Still, the original problem of #3528 reappeared, so I'm submitting the fix again.