### PR TITLE
Fix incorrect URL generation in getContentUrl()

### DIFF
--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -3331,7 +3331,7 @@ abstract class elFinderVolumeDriver
             }
         }
         if (empty($file['url']) && $this->URL) {
-            $path = str_replace($this->separator, '/', substr($this->decode($hash), strlen(trim($this->root, '/' . $this->separator))));
+            $path = str_replace($this->separator, '/', substr($this->decode($hash), strlen($this->root) + 1));
             if ($this->encoding) {
                 $path = $this->convEncIn($path, true);
             }


### PR DESCRIPTION
trim($this->root, '/') strips the leading slash from the root path, making strlen() return a value 1 less than expected. This causes substr() to include an extra character from the root folder name in the relative path.

For example, with root folder "images":
- Expected URL: /files/image.jpg
- Actual URL:   /files/s/image.jpg

Using strlen($this->root) + 1 is consistent with other URL construction methods in elFinderVolumeLocalFileSystem (lines 206, 612, 845, 1420) which all use this correct pattern.

Fixes #3746