### PR TITLE
Fixing bug where uploading large files sometimes fails

### DIFF
--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -4473,7 +4473,7 @@ var go = function() {
         foreach ($hashes as $hash) {
             $lock = elFinder::$commonTempPath . DIRECTORY_SEPARATOR . self::filenameDecontaminate($hash) . '.lock';
             if ($this->itemLocked($hash)) {
-                $cnt = file_get_contents($lock) + 1;
+                $cnt = (int)file_get_contents($lock) + 1;
             } else {
                 $cnt = 1;
             }


### PR DESCRIPTION
Sometimes uploading large files fails with the following error: Unsupported operand types: string + int {"userId":2,"exception":"[object] (TypeError(code: 0): Unsupported operand types: string + int at <path>/vendor/studio-42/elfinder/php/elFinder.php:4476). 

The function file_get_contents returns a string, and PHP 8 doesn't do implicit conversion. It requires the conversion to be explicit to not give problems.