### PR TITLE
Fix string trimming for translator names

### DIFF
--- a/js/commands/help.js
+++ b/js/commands/help.js
@@ -63,7 +63,7 @@
 			
 			if (fm.i18[fm.lang].translator) {
 				$.each(fm.i18[fm.lang].translator.split(', '), function() {
-					html.push(atpl[r](author, $.trim(this))[r](work, fm.i18n('translator')+' ('+fm.i18[fm.lang].language+')'));
+					html.push(atpl[r](author, this.trim())[r](work, fm.i18n('translator')+' ('+fm.i18[fm.lang].language+')'));
 				});	
 			}
 			


### PR DESCRIPTION
for jquery 4.0