### PR TITLE
fix: improve PHP 8 compatibility in session, cURL, and callback handling

### DIFF
--- a/php/connector.minimal.php-dist
+++ b/php/connector.minimal.php-dist
@@ -20,6 +20,8 @@ error_reporting(0); // Set E_ALL for debuging
 
 // define('ELFINDER_CONNECTOR_URL', 'URL to this connector script');  // see elFinder::getConnectorUrl()
 
+// define('ELFINDER_COOKIE_SAMESITE', 'None'); // It require when configuring with CORS.
+
 // define('ELFINDER_DEBUG_ERRORLEVEL', -1); // Error reporting level of debug mode
 
 // // To Enable(true) handling of PostScript files by ImageMagick

--- a/php/editors/OnlineConvert/editor.php
+++ b/php/editors/OnlineConvert/editor.php
@@ -89,7 +89,11 @@ class elFinderEditorOnlineConvert extends elFinderEditor
             $response = curl_exec($ch);
             $info = curl_getinfo($ch);
             $error = curl_error($ch);
-            curl_close($ch);
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($ch);
+            } else {
+                unset($ch);
+            }
 
             if (!empty($error)) {
                 $res = array('error' => $error);

--- a/php/editors/ZohoOffice/editor.php
+++ b/php/editors/ZohoOffice/editor.php
@@ -100,7 +100,11 @@ class elFinderEditorZohoOffice extends elFinderEditor
                     curl_setopt($ch, CURLOPT_COOKIEFILE, $cookie);
                 }
                 $res = curl_exec($ch);
-                curl_close($ch);
+                if (PHP_VERSION_ID < 80000) {
+                    curl_close($ch);
+                } else {
+                    unset($ch);
+                }
                 if ($res) {
                     if ($data = json_decode($res, true)) {
                         $save = !empty($data['cansave']);
@@ -169,7 +173,11 @@ class elFinderEditorZohoOffice extends elFinderEditor
                 curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
                 $res = curl_exec($ch);
                 $error = curl_error($ch);
-                curl_close($ch);
+                if (PHP_VERSION_ID < 80000) {
+                    curl_close($ch);
+                } else {
+                    unset($ch);
+                }
 
                 $fp && fclose($fp);
 

--- a/php/elFinder.class.php
+++ b/php/elFinder.class.php
@@ -672,6 +672,12 @@ class elFinder
                 'keys' => array(
                     'default' => !empty($opts['sessionCacheKey']) ? $opts['sessionCacheKey'] : 'elFinderCaches',
                     'netvolume' => !empty($opts['netVolumesSessionKey']) ? $opts['netVolumesSessionKey'] : 'elFinderNetVolumes'
+                ),
+                'cookieParams' => array(
+                    'path' => '/',
+                    'secure' => true,
+                    'httponly' => true,
+                    'samesite' => defined('ELFINDER_COOKIE_SAMESITE')? ELFINDER_COOKIE_SAMESITE : 'Lax'
                 )
             );
             if (!class_exists('elFinderSession')) {
@@ -2728,7 +2734,11 @@ class elFinder
             }
             return $this->curl_get_contents($new_url, $timeout, $redirect_max - 1, $ua, $outfp, $info);
         }
-        curl_close($ch);
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        } else {
+            unset($ch);
+        }
         return $outfp ? $outfp : $result;
     }
 
@@ -4203,10 +4213,27 @@ class elFinder
                 $script .= '
 var go = function() {
     var w = window.opener || window.parent || window,
-        close = function(){
-            window.open("about:blank","_self").close();
-            return false;
-        };
+    var closeWindow = function(){
+        try {
+            window.close();
+        } catch(e) {}
+        return false;
+    };
+    var showMessage = function() {
+        var msg = document.getElementById(\'msg\');
+        var link = msg && msg.getElementsByTagName(\'a\')[0];
+        if (msg) {
+            msg.style.display = \'inline\';
+        }
+        if (link) {
+            link.onclick = function(ev) {
+                if (ev && ev.preventDefault) {
+                    ev.preventDefault();
+                }
+                return closeWindow();
+            };
+        }
+    };
     try {
         var elf = w.document.getElementById(\'' . $node . '\').elfinder;
         if (elf) {
@@ -4226,14 +4253,17 @@ var go = function() {
         }
     } catch(e) {
         // for CORS
-        w.postMessage && w.postMessage(JSON.stringify({type:\'io.studio-42.github\',bind:\'' . $bind . '\',data:' . $json . '}), \'' . $origin . '\');
+        try {
+            w.postMessage && w.postMessage(JSON.stringify({
+                type: \'io.studio-42.github\',
+                bind: \'' . $bind . '\',
+                data: data
+            }), \'' . $origin . '\');
+        } catch (err) {}
     }
     close();
-    setTimeout(function() {
-        var msg = document.getElementById(\'msg\');
-        msg.style.display = \'inline\';
-        msg.onclick = close;
-    }, 100);
+    setTimeout(showMessage, 100);
+    return false;
 };
 ';
             }
@@ -5135,10 +5165,10 @@ var go = function() {
     /**
      * Call curl_exec() with supported redirect on `safe_mode` or `open_basedir`
      *
-     * @param resource $curl
-     * @param array    $options
-     * @param array    $headers
-     * @param array    $postData
+     * @param \CurlHandle $curl
+     * @param array       $options
+     * @param array       $headers
+     * @param array       $postData
      *
      * @throws \Exception
      * @return mixed
@@ -5175,7 +5205,11 @@ var go = function() {
             }
         }
 
-        curl_close($curl);
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($curl);
+        } else {
+            unset($curl);
+        }
 
         return $result;
     }

--- a/php/elFinderSession.php
+++ b/php/elFinderSession.php
@@ -18,14 +18,6 @@ class elFinderSession implements elFinderSessionInterface
     protected $started = false;
 
     /**
-     * To fix PHP bug that duplicate Set-Cookie header to be sent
-     *
-     * @var        boolean
-     * @see        https://bugs.php.net/bug.php?id=75554
-     */
-    protected $fixCookieRegist = false;
-
-    /**
      * Array of session keys of this instance
      *
      * @var        array
@@ -40,6 +32,13 @@ class elFinderSession implements elFinderSessionInterface
     protected $base64encode = false;
 
     /**
+     * Read session data and close immediately
+     *
+     * @var        boolean
+     */
+    protected $readOnly = false;
+
+    /**
      * Default options array
      *
      * @var        array
@@ -50,7 +49,8 @@ class elFinderSession implements elFinderSessionInterface
             'default' => 'elFinderCaches',
             'netvolume' => 'elFinderNetVolumes'
         ),
-        'cookieParams' => array()
+        'cookieParams' => array(),
+        'readOnly' => false
     );
 
     /**
@@ -65,8 +65,75 @@ class elFinderSession implements elFinderSessionInterface
         $this->opts = array_merge($this->opts, $opts);
         $this->base64encode = !empty($this->opts['base64encode']);
         $this->keys = $this->opts['keys'];
-        if (function_exists('apache_get_version') || $this->opts['cookieParams']) {
-            $this->fixCookieRegist = true;
+        $this->readOnly = !empty($this->opts['readOnly']);
+    }
+
+    /**
+     * Normalize cookie params for session_set_cookie_params()
+     *
+     * @return array
+     */
+    protected function getSessionCookieParams()
+    {
+        $secure = (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off');
+
+        $params = array(
+            'lifetime' => 0,
+            'path' => '/',
+            'domain' => '',
+            'secure' => $secure,
+            'httponly' => true
+        );
+
+        if (!empty($this->opts['cookieParams']) && is_array($this->opts['cookieParams'])) {
+            $params = array_merge($params, $this->opts['cookieParams']);
+        }
+
+        // absorb key case variations
+        if (isset($params['SameSite']) && !isset($params['samesite'])) {
+            $params['samesite'] = $params['SameSite'];
+            unset($params['SameSite']);
+        }
+        if (isset($params['HttpOnly']) && !isset($params['httponly'])) {
+            $params['httponly'] = $params['HttpOnly'];
+            unset($params['HttpOnly']);
+        }
+
+        return $params;
+    }
+
+    /**
+     * Apply session cookie params before session_start()
+     *
+     * @return void
+     */
+    protected function applySessionCookieParams()
+    {
+        $p = $this->getSessionCookieParams();
+
+        if (version_compare(PHP_VERSION, '7.3.0', '>=')) {
+            session_set_cookie_params(array(
+                'lifetime' => isset($p['lifetime']) ? (int)$p['lifetime'] : 0,
+                'path' => isset($p['path']) ? $p['path'] : '/',
+                'domain' => isset($p['domain']) ? $p['domain'] : '',
+                'secure' => !empty($p['secure']),
+                'httponly' => !empty($p['httponly']),
+                'samesite' => isset($p['samesite']) ? $p['samesite'] : 'Lax'
+            ));
+        } else {
+            // PHP 5.5 compatible
+            $path = isset($p['path']) ? $p['path'] : '/';
+            if (!empty($p['samesite'])) {
+                $path .= '; SameSite=' . $p['samesite'];
+            }
+
+            session_set_cookie_params(
+                isset($p['lifetime']) ? (int)$p['lifetime'] : 0,
+                $path,
+                isset($p['domain']) ? $p['domain'] : '',
+                !empty($p['secure']),
+                !empty($p['httponly'])
+            );
         }
     }
 
@@ -75,20 +142,19 @@ class elFinderSession implements elFinderSessionInterface
      */
     public function get($key, $empty = null)
     {
-        $closed = false;
+        $openedHere = false;
+
         if (!$this->started) {
-            $closed = true;
+            $openedHere = true;
             $this->start();
         }
 
         $data = null;
+        $session =& $this->getSessionRef($key);
+        $data = $session;
 
-        if ($this->started) {
-            $session =& $this->getSessionRef($key);
-            $data = $session;
-            if ($data && $this->base64encode) {
-                $data = $this->decodeData($data);
-            }
+        if ($data && $this->base64encode) {
+            $data = $this->decodeData($data);
         }
 
         $checkFn = null;
@@ -107,42 +173,49 @@ class elFinderSession implements elFinderSessionInterface
         }
 
         if (is_null($data) || ($checkFn && !$checkFn($data))) {
-            $session = $data = $empty;
+            $data = $empty;
         }
 
-        if ($closed) {
+        if ($openedHere && !$this->readOnly) {
             $this->close();
         }
 
         return $data;
     }
 
+
     /**
      * {@inheritdoc}
      */
     public function start()
     {
+        if ($this->started) {
+            return $this;
+        }
+
         set_error_handler(array($this, 'session_start_error'), E_NOTICE | E_WARNING);
 
-        // apache2 SAPI has a bug of session cookie register
-        // see https://bugs.php.net/bug.php?id=75554
-        // see https://github.com/php/php-src/pull/3231
-        if ($this->fixCookieRegist === true) {
-            if ((int)ini_get('session.use_cookies') === 1) {
-                if (ini_set('session.use_cookies', 0) === false) {
-                    $this->fixCookieRegist = false;
-                }
-            }
-        }
+        $this->applySessionCookieParams();
 
         if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
             if (session_status() !== PHP_SESSION_ACTIVE) {
-                session_start();
+                if ($this->readOnly && version_compare(PHP_VERSION, '7.0.0', '>=')) {
+                    session_start(array('read_and_close' => true));
+                    // read_and_close closes the PHP session immediately,
+                    // but mark this wrapper as initialized for the current operation.
+                    // close() is not needed after get() in this mode.
+                    $this->started = true;
+                    restore_error_handler();
+                    return $this;
+                } else {
+                    session_start();
+                }
             }
         } else {
             session_start();
         }
-        $this->started = session_id() ? true : false;
+
+        $this->started = (session_id() !== '');
 
         restore_error_handler();
 
@@ -220,25 +293,6 @@ class elFinderSession implements elFinderSessionInterface
     public function close()
     {
         if ($this->started) {
-            if ($this->fixCookieRegist === true) {
-                // regist cookie only once for apache2 SAPI
-                $cParm = session_get_cookie_params();
-                if ($this->opts['cookieParams'] && is_array($this->opts['cookieParams'])) {
-                    $cParm = array_merge($cParm, $this->opts['cookieParams']);
-                }
-                if (version_compare(PHP_VERSION, '7.3', '<')) {
-                    setcookie(session_name(), session_id(), 0, $cParm['path'] . (!empty($cParm['SameSite'])? '; SameSite=' . $cParm['SameSite'] : ''), $cParm['domain'], $cParm['secure'], $cParm['httponly']);
-                } else {
-                    $allows = array('expires' => true, 'path' => true, 'domain' => true, 'secure' => true, 'httponly' => true, 'samesite' => true);
-                    foreach(array_keys($cParm) as $_k) {
-                        if (!isset($allows[$_k])) {
-                            unset($cParm[$_k]);
-                        }
-                    }
-                    setcookie(session_name(), session_id(), $cParm);
-                }
-                $this->fixCookieRegist = false;
-            }
             session_write_close();
         }
         $this->started = false;

--- a/php/elFinderSessionInterface.php
+++ b/php/elFinderSessionInterface.php
@@ -30,10 +30,11 @@ interface elFinderSessionInterface
      *
      * @param   string $key   Target key
      * @param   mixed  $empty Return value of if session target key does not exist
+     *                 and explicit $empty can be used as a type hint
      *
      * @return  mixed
      **/
-    public function get($key, $empty = '');
+    public function get($key, $empty = null);
 
     /**
      * Set session data

--- a/php/elFinderVolumeDropbox2.class.php
+++ b/php/elFinderVolumeDropbox2.class.php
@@ -255,7 +255,11 @@ class elFinderVolumeDropbox2 extends elFinderVolumeDriver
         ]);
         curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
         $result = curl_exec($ch);
-        curl_close($ch);
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        } else {
+            unset($ch);
+        }
 
         $res = $result ? json_decode($result, true) : [];
 

--- a/php/plugins/Watermark/plugin.php
+++ b/php/plugins/Watermark/plugin.php
@@ -177,31 +177,31 @@ class elFinderPluginWatermark extends elFinderPlugin
             return false;
         }
 
-        $watermark_width = $watermarkImgInfo[0];
-        $watermark_height = $watermarkImgInfo[1];
+        $watermark_width = (int)$watermarkImgInfo[0];
+        $watermark_height = (int)$watermarkImgInfo[1];
 
         // Specified as a ratio to the image size
         if ($opts['ratio'] && $opts['ratio'] > 0 && $opts['ratio'] <= 1) {
             $maxW = $srcImgInfo[0] * $opts['ratio'] - ($opts['marginX'] * 2);
             $maxH = $srcImgInfo[1] * $opts['ratio'] - ($opts['marginY'] * 2);
             $dx = $dy = 0;
-            if (($maxW >= $watermarkImgInfo[0] && $maxH >= $watermarkImgInfo[0]) || ($maxW <= $watermarkImgInfo[0] && $maxH <= $watermarkImgInfo[0])) {
-                $dx = abs($srcImgInfo[0] - $watermarkImgInfo[0]);
-                $dy = abs($srcImgInfo[1] - $watermarkImgInfo[1]);
-            } else if ($maxW < $watermarkImgInfo[0]) {
+            if (($maxW >= $watermark_width && $maxH >= $watermark_width) || ($maxW <= $watermark_width && $maxH <= $watermark_width)) {
+                $dx = abs($srcImgInfo[0] - $watermark_width);
+                $dy = abs($srcImgInfo[1] - $watermark_height);
+            } else if ($maxW < $watermark_width) {
                 $dx = -1;
             } else {
                 $dy = -1;
             }
             if ($dx < $dy) {
                 $ww = $maxW;
-                $wh = $watermarkImgInfo[1] * ($ww / $watermarkImgInfo[0]);
+                $wh = $watermark_height * ($ww / $watermark_width);
             } else {
                 $wh = $maxH;
-                $ww = $watermarkImgInfo[0] * ($wh / $watermarkImgInfo[1]);
+                $ww = $watermark_width * ($wh / $watermark_height);
             }
-            $watermarkImgInfo[0] = $ww;
-            $watermarkImgInfo[1] = $wh;
+            $watermark_width = (int)$ww;
+            $watermark_height = (int)$wh;
         } else {
             $opts['ratio'] = null;
         }
@@ -214,10 +214,10 @@ class elFinderPluginWatermark extends elFinderPlugin
             $dest_x = $opts['marginX'];
         } else if (strpos($opts['position'], 'M') !== false) {
             // Middle
-            $dest_x = ($srcImgInfo[0] - $watermarkImgInfo[0]) / 2;
+            $dest_x = ($srcImgInfo[0] - $watermark_width) / 2;
         } else {
             // Bottom
-            $dest_x = $srcImgInfo[0] - $watermarkImgInfo[0] - max($opts['marginBottom'], $opts['marginX']);
+            $dest_x = $srcImgInfo[0] - $watermark_width - max($opts['marginBottom'], $opts['marginX']);
         }
 
         // Set horizontal position
@@ -226,10 +226,10 @@ class elFinderPluginWatermark extends elFinderPlugin
             $dest_y = $opts['marginY'];
         } else if (strpos($opts['position'], 'C') !== false) {
             // Middle
-            $dest_y = ($srcImgInfo[1] - $watermarkImgInfo[1]) / 2;
+            $dest_y = ($srcImgInfo[1] - $watermark_height) / 2;
         } else {
             // Right
-            $dest_y = $srcImgInfo[1] - $watermarkImgInfo[1] - max($opts['marginRight'], $opts['marginY']);
+            $dest_y = $srcImgInfo[1] - $watermark_height - max($opts['marginRight'], $opts['marginY']);
         }
 
 
@@ -258,7 +258,7 @@ class elFinderPluginWatermark extends elFinderPlugin
 
             // zoom
             if ($opts['ratio']) {
-                $watermark->scaleImage($watermarkImgInfo[0], $watermarkImgInfo[1]);
+                $watermark->scaleImage((int)$watermarkImgInfo[0], (int)$watermarkImgInfo[1]);
             }
 
             // Set transparency
@@ -296,8 +296,8 @@ class elFinderPluginWatermark extends elFinderPlugin
     private function watermarkPrint_gd($src, $watermark, $dest_x, $dest_y, $quality, $transparency, $watermarkImgInfo, $srcImgInfo, $opts)
     {
 
-        $watermark_width = $watermarkImgInfo[0];
-        $watermark_height = $watermarkImgInfo[1];
+        $watermark_width = (int)$watermarkImgInfo[0];
+        $watermark_height = (int)$watermarkImgInfo[1];
 
         $ermsg = '';
         switch ($watermarkImgInfo['mime']) {
@@ -339,11 +339,13 @@ class elFinderPluginWatermark extends elFinderPlugin
         if (!$ermsg) {
             // zoom
             if ($opts['ratio']) {
-                $tmpImg = imagecreatetruecolor($watermarkImgInfo[0], $watermarkImgInfo[1]);
+                $tmpImg = imagecreatetruecolor($watermark_width, $watermark_height);
                 imagealphablending($tmpImg, false);
                 imagesavealpha($tmpImg, true);
-                imagecopyresampled($tmpImg, $oWatermarkImg, 0, 0, 0, 0, $watermarkImgInfo[0], $watermarkImgInfo[1], imagesx($oWatermarkImg), imagesy($oWatermarkImg));
-                imageDestroy($oWatermarkImg);
+                imagecopyresampled($tmpImg, $oWatermarkImg, 0, 0, 0, 0, $watermark_width, $watermark_height, imagesx($oWatermarkImg), imagesy($oWatermarkImg));
+                if (function_exists('imagedestroy')) {
+                    @imageDestroy($oWatermarkImg);
+                }
                 $oWatermarkImg = $tmpImg;
                 $tmpImg = null;
             }
@@ -424,8 +426,10 @@ class elFinderPluginWatermark extends elFinderPlugin
                 break;
         }
 
-        imageDestroy($oSrcImg);
-        imageDestroy($oWatermarkImg);
+        if (function_exists('imagedestroy')) {
+            @imageDestroy($oSrcImg);
+            @imageDestroy($oWatermarkImg);
+        }
 
         return true;
     }


### PR DESCRIPTION
- replace curl_close() handling for PHP 8 CurlHandle compatibility
- refine session cookie params and read-only session behavior
- change session get() default fallback from '' to null
- improve OAuth callback window close/message fallback
- add type-safe adjustments in watermark processing