### PR TITLE
Fix postMessage origin bypass and playsound DOM XSS

### DIFF
--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -4979,9 +4979,6 @@ var elFinder = function(elm, opts, bootCallback) {
 			try {
 				trusted[new URL(self.convAbsUrl(self.uploadURL)).origin] = true;
 			} catch (ignore) {}
-			try {
-				trusted[window.location.origin] = true;
-			} catch (ignore) {}
 			if (res && res.origin && trusted[res.origin]) {
 				try {
 					try {
@@ -4998,7 +4995,7 @@ var elFinder = function(elm, opts, bootCallback) {
 					} 
 					if (data) {
 						bind = obj.bind;
-						if (bind && !/^[a-zA-Z0-9;._-]+$/.test(bind)) {
+						if (bind && !/^[a-zA-Z0-9._-]+$/.test(bind)) {
 							bind = '';
 						}
 						if (data.error) {

--- a/js/elFinder.js
+++ b/js/elFinder.js
@@ -4714,9 +4714,22 @@ var elFinder = function(elm, opts, bootCallback) {
 	if (true === this.options.sound) {
 		this.bind('playsound', function(e) {
 			var play  = beeper.canPlayType && beeper.canPlayType('audio/wav; codecs="1"'),
-				file = e.data && e.data.soundFile;
+				file = e.data && e.data.soundFile,
+				source;
 
-			play && file && play != '' && play != 'no' && $(beeper).html('<source src="' + soundPath + file + '" type="audio/wav">')[0].play();
+			// Reject non-wav / path-traversal / HTML-breakout soundFile values (DOM XSS)
+			if (!(play && file && play != '' && play != 'no')) {
+				return;
+			}
+			if (typeof file !== 'string' || !/^[A-Za-z0-9._-]+\.wav$/.test(file)) {
+				return;
+			}
+			beeper.innerHTML = '';
+			source = document.createElement('source');
+			source.src = soundPath + file;
+			source.type = 'audio/wav';
+			beeper.appendChild(source);
+			beeper.play();
 		});
 	}
 
@@ -4958,8 +4971,18 @@ var elFinder = function(elm, opts, bootCallback) {
 		// bind window onmessage for CORS
 		$(window).on('message.' + namespace, function(e){
 			var res = e.originalEvent || null,
-				obj, data;
-			if (res && (self.convAbsUrl(self.options.url).indexOf(res.origin) === 0 || self.convAbsUrl(self.uploadURL).indexOf(res.origin) === 0)) {
+				obj, data, bind, trusted = {};
+			// Exact-origin match only (prefix indexOf check allowed origin bypass)
+			try {
+				trusted[new URL(self.convAbsUrl(self.options.url)).origin] = true;
+			} catch (ignore) {}
+			try {
+				trusted[new URL(self.convAbsUrl(self.uploadURL)).origin] = true;
+			} catch (ignore) {}
+			try {
+				trusted[window.location.origin] = true;
+			} catch (ignore) {}
+			if (res && res.origin && trusted[res.origin]) {
 				try {
 					try {
 						if (typeof res.data !== 'string') {
@@ -4974,9 +4997,13 @@ var elFinder = function(elm, opts, bootCallback) {
 						return;
 					} 
 					if (data) {
+						bind = obj.bind;
+						if (bind && !/^[a-zA-Z0-9;._-]+$/.test(bind)) {
+							bind = '';
+						}
 						if (data.error) {
-							if (obj.bind) {
-								self.trigger(obj.bind+'fail', data);
+							if (bind) {
+								self.trigger(bind+'fail', data);
 							}
 							self.error(data.error);
 						} else {
@@ -4985,9 +5012,9 @@ var elFinder = function(elm, opts, bootCallback) {
 							data.removed && data.removed.length && self.remove(data);
 							data.added   && data.added.length   && self.add(data);
 							data.changed && data.changed.length && self.change(data);
-							if (obj.bind) {
-								self.trigger(obj.bind, data);
-								self.trigger(obj.bind+'done');
+							if (bind) {
+								self.trigger(bind, data);
+								self.trigger(bind+'done');
 							}
 							data.sync && self.sync();
 						}


### PR DESCRIPTION
## Summary
- Replace prefix `indexOf(origin)` with exact `URL.origin` matching
- Prevent playsound DOM XSS via filename allowlist + DOM APIs
- Sanitize untrusted `bind` from postMessage payloads

## Test plan
- [ ] Same-origin / connector-origin postMessage still works
- [ ] Prefix attacker origin is rejected
- [ ] Malicious `soundFile` does not inject HTML / XSS
- [ ] Normal `rm.wav` still plays when sound is enabled

## Credit
WPExperts / Advanced File Manager